### PR TITLE
feat(home): единый стандарт ширины, порт главной по Claude Design и п…

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -7,6 +7,15 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Фирменные шрифты. Обычный @theme (не inline) — переменные должны попасть
+   в CSS, т.к. портированная вёрстка ссылается на var(--font-sans) напрямую. */
+@theme {
+  --font-sans:
+    'Nunito', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-display: 'Montserrat Alternates', var(--font-sans);
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -44,6 +53,22 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  /* Утилиты для фирменных токенов: text-bonus, bg-brand-surface, … */
+  --color-brand: var(--brand);
+  --color-brand-hover: var(--brand-hover);
+  --color-brand-surface: var(--brand-surface);
+  --color-price: var(--price);
+  --color-price-old: var(--price-old);
+  --color-discount: var(--discount);
+  --color-sold-out: var(--sold-out);
+  --color-bonus: var(--bonus);
+  --color-bonus-surface: var(--bonus-surface);
+  --color-bonus-border: var(--bonus-border);
+  --color-rating: var(--rating);
+  --color-rating-empty: var(--rating-empty);
+  --color-product-line: var(--product-line);
+  --color-success: var(--success);
 }
 
 :root {
@@ -80,6 +105,40 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* ============================================================
+     Фирменные семантические токены (дизайн-система Ухтышка).
+     ВАЖНО: значения записаны литералами, а НЕ через var(--color-*).
+     Tailwind 4 выкидывает переменную темы, если для неё не сгенерирована
+     ни одна утилита, — ссылка на такую переменную работает в dev
+     и молча ломается в проде.
+     ============================================================ */
+  --brand: oklch(62.3% 0.214 259.815); /* blue-500 */
+  --brand-hover: oklch(54.6% 0.245 262.881); /* blue-600 */
+  --brand-active: oklch(48.8% 0.243 264.376); /* blue-700 */
+  --brand-surface: oklch(97% 0.014 254.604); /* blue-50 */
+  --header-bg: oklch(62.3% 0.214 259.815);
+
+  --price: oklch(62.3% 0.214 259.815);
+  --price-old: var(--muted-foreground);
+  --discount: oklch(57.7% 0.245 27.325); /* red-600 */
+  --sold-out: oklch(55.1% 0.027 264.364); /* gray-500 */
+
+  --bonus: oklch(64.6% 0.222 41.116); /* orange-600 */
+  --bonus-surface: oklch(98% 0.016 73.684); /* orange-50 */
+  --bonus-border: oklch(90.1% 0.076 70.697); /* orange-200 */
+
+  --rating: oklch(85.2% 0.199 91.936); /* yellow-400 */
+  --rating-empty: oklch(87.2% 0.01 258.338); /* gray-300 */
+  --product-line: oklch(59.2% 0.249 0.584); /* pink-600 */
+  --success: oklch(72.3% 0.219 149.579); /* green-500 */
+
+  --shadow-brand: 0 8px 18px -8px rgb(43 127 255 / 0.8);
+  --shadow-brand-strong: 0 20px 46px -20px rgb(43 127 255 / 0.7);
+  --shadow-glass: 0 10px 30px rgb(15 23 42 / 0.2);
+  --elevation-card: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --elevation-card-hover:
+    0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
 }
 
 .dark {
@@ -115,6 +174,58 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.269 0 0);
   --sidebar-ring: oklch(0.439 0 0);
+
+  /* Зеркалим только «почти белые» поверхности — на тёмном фоне они
+     нечитаемы. Константы бренда (--brand, --price, --bonus и т.п.)
+     намеренно остаются едиными для обеих тем. */
+  --brand-surface: oklch(37.9% 0.146 265.522); /* blue-900 */
+  --bonus-surface: oklch(26.6% 0.079 36.259); /* orange-950 */
+  --bonus-border: oklch(47.3% 0.137 46.201); /* orange-800 */
+  --rating-empty: oklch(37.3% 0.034 259.733); /* gray-700 */
+  --sold-out: oklch(70.7% 0.022 261.325); /* gray-400 */
+  --elevation-card: 0 1px 2px 0 rgb(0 0 0 / 0.4);
+  --elevation-card-hover:
+    0 20px 25px -5px rgb(0 0 0 / 0.5), 0 8px 10px -6px rgb(0 0 0 / 0.5);
+}
+
+/* ============================================================
+   Горизонтальный ритм страницы — ЕДИНЫЙ ИСТОЧНИК ПРАВДЫ.
+
+   --page-gutter — боковой отступ контента от края экрана. На него
+   обязаны ссылаться ВСЕ, кто задаёт ширину контента:
+     • carouselContainerVariants в lib/variants.ts (always / desktop / false);
+     • .app-container ниже;
+     • edge-bleed рельсы в scoped-стилях компонентов —
+       margin-inline: calc(-1 * var(--page-gutter));
+       padding-inline: var(--page-gutter);
+
+   НЕ хардкодьте отступ числом и не пишите свой clamp(): рельсы, которые
+   вылезают за контейнер, дают горизонтальный скролл всей страницы, а
+   секции с «почти таким же» отступом визуально разъезжаются.
+
+   Значения = шкала Tailwind 4/6/8/12 (16/24/32/48px) на брейкпоинтах
+   sm/md/lg — именно так исторически был свёрстан .app-container.
+   ============================================================ */
+:root {
+  --page-gutter: 1rem; /* < 640px → 16px */
+}
+
+@media (width >= 40rem) {
+  :root {
+    --page-gutter: 1.5rem; /* sm → 24px */
+  }
+}
+
+@media (width >= 48rem) {
+  :root {
+    --page-gutter: 2rem; /* md → 32px */
+  }
+}
+
+@media (width >= 64rem) {
+  :root {
+    --page-gutter: 3rem; /* lg+ → 48px */
+  }
 }
 
 /* Базовые стили - ТОЛЬКО ЗДЕСЬ, удалите из app.vue */
@@ -130,8 +241,10 @@
       'calt' 1;
   }
 
+  /* Легаси-алиас для carouselContainerVariants({ contained: 'always' }).
+     В новом коде используйте вариант из lib/variants.ts. */
   .app-container {
-    @apply container max-w-screen-2xl mx-auto px-4 sm:px-6 md:px-8 lg:px-12;
+    @apply container max-w-screen-2xl mx-auto px-[var(--page-gutter)];
   }
 
   .sr-only {

--- a/components/category/CategoryMobileHeader.vue
+++ b/components/category/CategoryMobileHeader.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+defineProps<{
+  sortActive: boolean
+  filtersActive: boolean
+  hasActiveFilters: boolean
+}>()
+
+defineEmits<{
+  sort: []
+  filters: []
+}>()
+
+// Scroll-aware visibility: hide once scrolled past 280px while moving down,
+// reveal again on any upward scroll or once back near the top. Mirrors
+// MobileBottomNav.vue's thresholds for a consistent feel across the app's
+// scroll-hiding chrome (this one slides up instead of down).
+const isHidden = ref(false)
+let lastScrollY = 0
+let ticking = false
+
+function applyScroll() {
+  ticking = false
+  const y = window.scrollY
+  const dy = y - lastScrollY
+  if (dy > 6 && y > 280)
+    isHidden.value = true
+  else if (dy < -6 || y < 120)
+    isHidden.value = false
+  lastScrollY = y
+}
+
+function onScroll() {
+  if (!ticking) {
+    ticking = true
+    requestAnimationFrame(applyScroll)
+  }
+}
+
+onMounted(() => {
+  lastScrollY = window.scrollY
+  window.addEventListener('scroll', onScroll, { passive: true })
+})
+onUnmounted(() => window.removeEventListener('scroll', onScroll))
+</script>
+
+<template>
+  <div class="cmh-bar lg:hidden" :class="{ 'cmh-bar--hidden': isHidden }">
+    <div class="cmh-pill">
+      <NuxtLink to="/" class="cmh-logo" aria-label="Ухтышка — на главную">
+        <svg viewBox="11 0 64 78" width="22" height="27" aria-hidden="true">
+          <g transform="translate(2 0)"><g transform="rotate(-9 42 72)">
+            <rect x="37.5" y="4" width="9" height="13" rx="4.5" fill="#fff" />
+            <rect x="34" y="15.5" width="16" height="5.5" rx="2.75" fill="rgba(255,255,255,.65)" />
+            <path d="M16 36 C16 22.5 68 22.5 68 36 L68 36.5 C68 40.6 64.6 44 60.5 44 L23.5 44 C19.4 44 16 40.6 16 36.5 Z" fill="#fff" />
+            <rect x="20" y="46.5" width="44" height="6" rx="3" fill="#ffd34d" />
+            <path d="M23 55 L61 55 C57.5 61.5 50 64 45 70 A3.8 3.8 0 0 1 39 70 C34 64 26.5 61.5 23 55 Z" fill="#ff8ac2" />
+          </g></g>
+        </svg>
+      </NuxtLink>
+
+      <CommonSiteHeaderSearch dense />
+
+      <button
+        type="button"
+        class="cmh-icon-btn"
+        :class="{ 'cmh-icon-btn--active': sortActive }"
+        aria-label="Сортировка"
+        @click="$emit('sort')"
+      >
+        <Icon name="lucide:arrow-up-down" class="cmh-icon" />
+      </button>
+
+      <ClientOnly>
+        <button
+          type="button"
+          class="cmh-icon-btn"
+          :class="{ 'cmh-icon-btn--active': filtersActive }"
+          aria-label="Фильтры"
+          @click="$emit('filters')"
+        >
+          <Icon name="lucide:sliders-horizontal" class="cmh-icon" />
+          <span v-if="hasActiveFilters" class="cmh-badge bg-orange-500" />
+        </button>
+      </ClientOnly>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cmh-bar {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  padding: 10px 12px 4px;
+  transition:
+    opacity 0.28s ease,
+    transform 0.28s cubic-bezier(0.32, 0.72, 0.33, 1);
+}
+
+.cmh-bar--hidden {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-140%);
+}
+
+.cmh-pill {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 8px;
+  border-radius: 20px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.62), rgba(255, 255, 255, 0.26));
+  backdrop-filter: blur(24px) saturate(1.9);
+  -webkit-backdrop-filter: blur(24px) saturate(1.9);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -1px 1px rgba(15, 23, 42, 0.05),
+    0 12px 32px rgba(15, 23, 42, 0.16);
+}
+
+.cmh-logo {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  background: var(--primary);
+  display: grid;
+  place-content: center;
+  box-shadow: var(--shadow-brand);
+  text-decoration: none;
+}
+
+.cmh-icon-btn {
+  position: relative;
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--foreground);
+  cursor: pointer;
+  display: grid;
+  place-content: center;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.cmh-icon-btn--active {
+  background: rgba(43, 127, 255, 0.16);
+  color: var(--primary);
+}
+
+.cmh-icon {
+  width: 19px;
+  height: 19px;
+}
+
+.cmh-badge {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  border: 2px solid #fff;
+}
+</style>

--- a/components/category/CategoryScrollBar.vue
+++ b/components/category/CategoryScrollBar.vue
@@ -1,0 +1,434 @@
+<script setup lang="ts">
+import type { BrandForFilter, CategoryRow, SortByType } from '@/types'
+import { useCartStore } from '@/stores/publicStore/cartStore'
+
+const props = withDefaults(defineProps<{
+  subcategories?: CategoryRow[]
+  activeSubcategoryIds?: string[]
+  brands?: BrandForFilter[]
+  activeBrandIds?: string[]
+}>(), {
+  subcategories: () => [],
+  activeSubcategoryIds: () => [],
+  brands: () => [],
+  activeBrandIds: () => [],
+})
+
+const emit = defineEmits<{ toggleSubcategory: [id: string], toggleBrand: [id: string] }>()
+
+const sortBy = defineModel<SortByType>('sortBy', { required: true })
+
+const cartStore = useCartStore()
+const cartCount = computed(() => cartStore.items.length)
+
+const sortOptions: { value: SortByType, label: string }[] = [
+  { value: 'popularity', label: 'Популярные' },
+  { value: 'newest', label: 'По новизне' },
+  { value: 'price_asc', label: 'Цена: по возрастанию' },
+  { value: 'price_desc', label: 'Цена: по убыванию' },
+]
+
+const currentSortLabel = computed(
+  () => sortOptions.find(o => o.value === sortBy.value)?.label ?? sortOptions[0].label,
+)
+
+const sortOpen = ref(false)
+const catOpen = ref(false)
+const brandOpen = ref(false)
+
+// Three independent Popovers, but only one open at a time (mirrors the
+// catToggle()/brandToggle()/onCloseSort() coupling in CatalogScrollBar.dc.html).
+watch(sortOpen, (open) => {
+  if (open) {
+    catOpen.value = false
+    brandOpen.value = false
+  }
+})
+watch(catOpen, (open) => {
+  if (open) {
+    sortOpen.value = false
+    brandOpen.value = false
+  }
+})
+watch(brandOpen, (open) => {
+  if (open) {
+    sortOpen.value = false
+    catOpen.value = false
+  }
+})
+
+function selectSort(value: SortByType) {
+  sortBy.value = value
+  sortOpen.value = false
+}
+
+function onToggleSubcategory(id: string) {
+  emit('toggleSubcategory', id)
+}
+
+function onToggleBrand(id: string) {
+  emit('toggleBrand', id)
+}
+
+// Self-contained scroll visibility, same convention as CategoryMobileHeader:
+// hidden until the user has scrolled well past the category header, so the
+// bar only appears once the page's own in-flow controls are out of reach.
+const shown = ref(false)
+let ticking = false
+
+function applyScroll() {
+  ticking = false
+  shown.value = window.scrollY > 400
+}
+
+function onScroll() {
+  if (!ticking) {
+    ticking = true
+    requestAnimationFrame(applyScroll)
+  }
+}
+
+// Close any open menu when the bar itself slides away, so a teleported
+// Popover never floats detached from its (now invisible) trigger.
+watch(shown, (visible) => {
+  if (!visible) {
+    sortOpen.value = false
+    catOpen.value = false
+    brandOpen.value = false
+  }
+})
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll, { passive: true })
+  shown.value = window.scrollY > 400
+})
+onUnmounted(() => window.removeEventListener('scroll', onScroll))
+</script>
+
+<template>
+  <div class="hidden lg:block csb-bar" :class="{ 'csb-bar--shown': shown }">
+    <div class="csb-inner">
+      <div class="csb-capsule">
+        <div class="csb-search">
+          <CommonSiteHeaderSearch dense show-submit-button />
+        </div>
+
+        <Popover v-model:open="sortOpen">
+          <PopoverTrigger as-child>
+            <button type="button" class="csb-pill" :class="{ 'csb-pill--active': sortOpen }">
+              {{ currentSortLabel }}
+              <Icon name="lucide:chevron-down" class="csb-chev" :class="{ 'csb-chev--open': sortOpen }" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            :side-offset="8"
+            class="w-56 p-1.5 rounded-2xl bg-white/90 backdrop-blur-xl border-white/70 shadow-xl flex flex-col gap-0.5"
+          >
+            <button
+              v-for="opt in sortOptions"
+              :key="opt.value"
+              type="button"
+              class="csb-item"
+              :class="{ 'csb-item--active': sortBy === opt.value }"
+              @click="selectSort(opt.value)"
+            >
+              {{ opt.label }}
+            </button>
+          </PopoverContent>
+        </Popover>
+
+        <Popover v-if="props.subcategories.length > 0" v-model:open="catOpen">
+          <PopoverTrigger as-child>
+            <button type="button" class="csb-pill" :class="{ 'csb-pill--active': catOpen }">
+              <span>Категории</span>
+              <span v-if="props.activeSubcategoryIds.length > 0" class="csb-pill-badge">{{ props.activeSubcategoryIds.length }}</span>
+              <Icon name="lucide:chevron-down" class="csb-chev" :class="{ 'csb-chev--open': catOpen }" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            :side-offset="8"
+            class="w-64 p-1.5 rounded-2xl bg-white/90 backdrop-blur-xl border-white/70 shadow-xl flex flex-col gap-0.5 max-h-[70vh] overflow-y-auto"
+          >
+            <button
+              v-for="cat in props.subcategories"
+              :key="cat.id"
+              type="button"
+              class="csb-item"
+              :class="{ 'csb-item--active': props.activeSubcategoryIds.includes(cat.id) }"
+              @click="onToggleSubcategory(cat.id)"
+            >
+              <span class="csb-item__label">{{ cat.name }}</span>
+              <Icon v-if="props.activeSubcategoryIds.includes(cat.id)" name="lucide:check" class="csb-item__check" />
+            </button>
+          </PopoverContent>
+        </Popover>
+
+        <!-- Бренды — из обновлённого CatalogScrollBar.dc.html. «Возраст» из того же
+           макета сознательно не портирован: нет ни одного реального атрибута/колонки
+           под возрастные диапазоны в каталоге (min_age_years/max_age_years есть только
+           у персональных рекомендаций по детям, не у фильтрации каталога) — фиктивные
+           бакеты вида «0–1 год» добавлять не стали, тот же принцип, что и со «Скидкой»
+           в Категория.dc.html. -->
+        <Popover v-if="props.brands.length > 0" v-model:open="brandOpen">
+          <PopoverTrigger as-child>
+            <button type="button" class="csb-pill" :class="{ 'csb-pill--active': brandOpen }">
+              <span>Бренды</span>
+              <span v-if="props.activeBrandIds.length > 0" class="csb-pill-badge">{{ props.activeBrandIds.length }}</span>
+              <Icon name="lucide:chevron-down" class="csb-chev" :class="{ 'csb-chev--open': brandOpen }" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            :side-offset="8"
+            class="w-60 p-1.5 rounded-2xl bg-white/90 backdrop-blur-xl border-white/70 shadow-xl flex flex-col gap-0.5 max-h-[70vh] overflow-y-auto"
+          >
+            <button
+              v-for="brand in props.brands"
+              :key="brand.id"
+              type="button"
+              class="csb-item"
+              :class="{ 'csb-item--active': props.activeBrandIds.includes(brand.id) }"
+              @click="onToggleBrand(brand.id)"
+            >
+              <span class="csb-item__label">{{ brand.name }}</span>
+              <Icon v-if="props.activeBrandIds.includes(brand.id)" name="lucide:check" class="csb-item__check" />
+            </button>
+          </PopoverContent>
+        </Popover>
+
+        <NuxtLink to="/cart" aria-label="Корзина" class="csb-cart">
+          <Icon name="solar:cart-3-bold" class="csb-cart__icon" />
+          <ClientOnly>
+            <span v-if="cartCount > 0" class="csb-cart-badge">{{ cartCount > 9 ? '9+' : cartCount }}</span>
+          </ClientOnly>
+        </NuxtLink>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.csb-bar {
+  /* top:0, not 74px — SiteHeader renders non-sticky on this page
+     (:sticky="false" in layouts/CatalogListing.vue), so nothing fixed sits
+     above this bar to dock under. Transparent + just vertical padding: the
+     bar itself carries no chrome any more, the floating glass capsule below
+     is what's actually visible (matches the updated .dc.html). */
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 90;
+  padding: 10px 0 4px;
+  opacity: 0;
+  transform: translateY(-130%);
+  pointer-events: none;
+  transition:
+    transform 0.3s cubic-bezier(0.32, 0.72, 0.33, 1),
+    opacity 0.3s ease;
+}
+
+.csb-bar--shown {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.csb-inner {
+  /* Matches the real page container (carouselContainerVariants({ contained:
+     'always' }) → container max-w-screen-2xl + px-[var(--page-gutter)]), not
+     the .dc.html mockup's own isolated-preview 1360px/clamp() — this bar sits
+     directly above that container's content and must line up with its edges.
+     Отступ берём из той же переменной, а не числом. */
+  max-width: 1536px;
+  margin: 0 auto;
+  padding: 0 var(--page-gutter);
+}
+
+.csb-capsule {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 8px;
+  border-radius: 24px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.62), rgba(255, 255, 255, 0.26));
+  backdrop-filter: blur(24px) saturate(1.9);
+  -webkit-backdrop-filter: blur(24px) saturate(1.9);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -1px 1px rgba(15, 23, 42, 0.05),
+    0 12px 32px rgba(15, 23, 42, 0.16);
+}
+
+.csb-search {
+  /* Capped, not left to fill all remaining space: at the real container's
+     1536px width (see .csb-inner) an uncapped SiteHeaderSearch (itself
+     flex:1 internally) ballooned to ~900px, swamping the row and reducing
+     Сортировка/Категории/Бренды to a squeezed cluster at the far right.
+     Bounded back to a normal pill-sized search field; the freed-up space
+     flows to the gap before .csb-cart via its own margin-left:auto. */
+  flex: 1 1 320px;
+  min-width: 290px;
+  max-width: 420px;
+}
+
+/* Более явный вид поисковой строки в этой капсуле — стандартный
+   .sh-search--dense рассчитан на мобильную плашку (там фон и так
+   контрастирует, а прямоугольная rounded-12px форма не соседствует с
+   pill-кнопками). Здесь та же полупрозрачность сливалась со стеклянной
+   капсулой, а прямые углы читались как случайный прямоугольник среди
+   круглых .csb-pill — из-за этого поиск не опознавался как часть общего
+   ряда управляющих элементов. Форма и тень теперь буквально повторяют
+   .csb-pill (капсула + тот же 3-слойный inset/drop shadow), просто с
+   непрозрачным белым фоном вместо стеклянного градиента — читается как
+   явный, приподнятый контрол, а не плоский прямоугольник. Переопределяем
+   только для этого потребителя, не трогая CommonSiteHeaderSearch.vue —
+   мобильная плашка использует те же классы. */
+.csb-search :deep(.sh-search--dense) {
+  background: #fff;
+  border-radius: 999px;
+  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    inset 0 -1px 2px rgba(15, 23, 42, 0.06),
+    0 6px 18px rgba(15, 23, 42, 0.1);
+}
+
+.csb-pill {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 38px;
+  padding: 0 15px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.9), rgba(224, 233, 247, 0.55));
+  backdrop-filter: blur(14px) saturate(1.7);
+  -webkit-backdrop-filter: blur(14px) saturate(1.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    inset 0 -1px 2px rgba(15, 23, 42, 0.06),
+    0 6px 18px rgba(15, 23, 42, 0.1);
+  font: 600 13.5px var(--font-sans);
+  color: var(--foreground);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.csb-pill--active {
+  border-color: var(--primary);
+  background: linear-gradient(150deg, rgba(219, 234, 254, 0.95), rgba(191, 219, 254, 0.6));
+}
+
+.csb-pill-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font: 700 11px var(--font-sans);
+}
+
+.csb-chev {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  color: var(--primary);
+  transition: transform 0.2s ease;
+}
+
+.csb-chev--open {
+  transform: rotate(180deg);
+}
+
+.csb-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  cursor: pointer;
+  font: 400 14.5px var(--font-sans);
+  color: var(--foreground);
+  white-space: nowrap;
+  transition: background 0.12s ease;
+}
+
+.csb-item:hover {
+  background: var(--muted);
+}
+
+.csb-item--active {
+  font-weight: 700;
+}
+
+.csb-item__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.csb-item__check {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  color: var(--primary);
+}
+
+.csb-cart {
+  position: relative;
+  flex: none;
+  margin-left: auto;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.9), rgba(224, 233, 247, 0.55));
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    0 4px 12px rgba(15, 23, 42, 0.1);
+  display: grid;
+  place-content: center;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+
+.csb-cart:hover {
+  background: rgba(43, 127, 255, 0.12);
+}
+
+.csb-cart__icon {
+  width: 20px;
+  height: 20px;
+  color: var(--primary);
+}
+
+.csb-cart-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #fff;
+  font: 700 10.5px var(--font-sans);
+  display: grid;
+  place-content: center;
+  border: 2px solid #fff;
+}
+</style>

--- a/components/category/MobileCatalogDrawer.vue
+++ b/components/category/MobileCatalogDrawer.vue
@@ -1,0 +1,915 @@
+<script setup lang="ts">
+import type { PropType } from 'vue'
+import type { AttributeWithValue, BrandForFilter, ColorOptionMeta, Country, Material, ProductLine } from '@/types'
+import { useCategoriesStore } from '@/stores/publicStore/categoriesStore'
+
+interface NumericAttributeRange {
+  min: number
+  max: number
+}
+
+// --- 1. PROPS & EMITS ---
+// Тот же контракт, что и у DynamicFiltersMobile.vue — прямой drop-in replacement.
+const props = defineProps({
+  modelValue: {
+    type: Object as PropType<{
+      subCategoryIds: string[]
+      price: [number, number]
+      pieceCount: [number, number] | null
+      brandIds: string[]
+      productLineIds: string[]
+      materialIds: string[]
+      countryIds: string[]
+      attributes: Record<string, (string | number)[]>
+      numericAttributes: Record<number, [number, number]>
+    }>,
+    required: true,
+  },
+  isLoading: { type: Boolean, default: false },
+  priceRange: {
+    type: Object as PropType<{ min: number, max: number }>,
+    required: true,
+  },
+  pieceCountRange: {
+    type: Object as PropType<{ min: number, max: number } | null>,
+    default: null,
+  },
+  availableBrands: {
+    type: Array as PropType<BrandForFilter[]>,
+    default: () => [],
+  },
+  availableProductLines: {
+    type: Array as PropType<ProductLine[]>,
+    default: () => [],
+  },
+  availableMaterials: {
+    type: Array as PropType<Material[]>,
+    default: () => [],
+  },
+  availableCountries: {
+    type: Array as PropType<Country[]>,
+    default: () => [],
+  },
+  availableFilters: {
+    type: Array as PropType<AttributeWithValue[]>,
+    default: () => [],
+  },
+  numericAttributeRanges: {
+    type: Object as PropType<Record<number, NumericAttributeRange>>,
+    default: () => ({}),
+  },
+  open: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const emit = defineEmits(['update:modelValue', 'update:open'])
+
+// --- 2. ЛОКАЛЬНОЕ СОСТОЯНИЕ И COMPUTEDS ---
+const categoriesStore = useCategoriesStore()
+const route = useRoute()
+
+const currentCategorySlug = computed(() => (route.params.slug as string[]).slice(-1)[0] ?? null)
+const subcategories = computed(() => categoriesStore.getSubcategories(currentCategorySlug.value))
+
+// select/checkbox-группы (карточки с рядами-чекбоксами)
+const checkboxFilters = computed(() => {
+  return props.availableFilters.filter(f => f.display_type === 'select')
+})
+
+// Атрибуты с цветовыми свотчами — отдельная секция с сеткой
+const colorFilters = computed(() => {
+  return props.availableFilters.filter(f => f.display_type === 'color')
+})
+
+// Числовые атрибуты — слайдеры
+const numericFilters = computed(() => {
+  return props.availableFilters.filter(f => f.display_type === 'numeric')
+})
+
+const localPrice = ref<[number, number]>([...props.modelValue.price])
+const localPieceCount = ref<[number, number] | null>(props.modelValue.pieceCount ? [...props.modelValue.pieceCount] : null)
+const localNumericAttributes = ref<Record<number, [number, number]>>(
+  props.modelValue.numericAttributes ? { ...props.modelValue.numericAttributes } : {},
+)
+
+const priceMinInput = ref('')
+const priceMaxInput = ref('')
+
+function syncPriceInputs() {
+  priceMinInput.value = String(Math.round(localPrice.value[0]))
+  priceMaxInput.value = String(Math.round(localPrice.value[1]))
+}
+syncPriceInputs()
+
+// Подсчет активных фильтров
+const activeFiltersCount = computed(() => {
+  let count = 0
+
+  count += props.modelValue.subCategoryIds.length
+  count += props.modelValue.brandIds.length
+  count += props.modelValue.productLineIds?.length || 0
+  count += props.modelValue.materialIds.length
+  count += props.modelValue.countryIds.length
+
+  Object.values(props.modelValue.attributes).forEach((values) => {
+    count += values.length
+  })
+
+  if (props.modelValue.price[0] !== props.priceRange.min
+    || props.modelValue.price[1] !== props.priceRange.max) {
+    count += 1
+  }
+
+  if (props.pieceCountRange && props.modelValue.pieceCount) {
+    if (props.modelValue.pieceCount[0] !== props.pieceCountRange.min
+      || props.modelValue.pieceCount[1] !== props.pieceCountRange.max) {
+      count += 1
+    }
+  }
+
+  if (props.modelValue.numericAttributes) {
+    Object.entries(props.modelValue.numericAttributes).forEach(([attrId, range]) => {
+      const attrRange = props.numericAttributeRanges[Number(attrId)]
+      if (attrRange && (range[0] !== attrRange.min || range[1] !== attrRange.max)) {
+        count += 1
+      }
+    })
+  }
+
+  return count
+})
+
+const hasActiveFilters = computed(() => activeFiltersCount.value > 0)
+
+// --- 3. ОБРАБОТЧИКИ ИЗМЕНЕНИЙ ---
+
+function updateSubCategory(catId: string) {
+  const newIds = new Set(props.modelValue.subCategoryIds)
+  if (newIds.has(catId))
+    newIds.delete(catId)
+  else newIds.add(catId)
+  emit('update:modelValue', { ...props.modelValue, subCategoryIds: Array.from(newIds) })
+}
+
+function updateAttribute(attributeSlug: string, optionId: string | number) {
+  const stringId = String(optionId)
+  const currentSelection: string[] = (props.modelValue.attributes[attributeSlug] || []).map(String)
+  const newSelection = new Set<string>(currentSelection)
+
+  if (newSelection.has(stringId))
+    newSelection.delete(stringId)
+  else newSelection.add(stringId)
+
+  emit('update:modelValue', {
+    ...props.modelValue,
+    attributes: {
+      ...props.modelValue.attributes,
+      [attributeSlug]: Array.from(newSelection),
+    },
+  })
+}
+
+function updateDirectFilter(key: 'brandIds' | 'productLineIds' | 'materialIds' | 'countryIds', id: string | number) {
+  const stringId = String(id)
+  const currentSelection: string[] = (props.modelValue[key] || []).map(String)
+  const newSelection = new Set<string>(currentSelection)
+
+  if (newSelection.has(stringId))
+    newSelection.delete(stringId)
+  else newSelection.add(stringId)
+
+  emit('update:modelValue', {
+    ...props.modelValue,
+    [key]: Array.from(newSelection),
+  })
+}
+
+function commitPriceToFilters(newPrice: number[]) {
+  if (Array.isArray(newPrice) && newPrice.length === 2) {
+    emit('update:modelValue', { ...props.modelValue, price: newPrice as [number, number] })
+  }
+}
+
+function onPriceMinChange() {
+  const parsed = Number(priceMinInput.value.replace(/\D/g, ''))
+  const min = Number.isFinite(parsed) && priceMinInput.value !== '' ? parsed : props.priceRange.min
+  commitPriceToFilters([min, localPrice.value[1]])
+}
+
+function onPriceMaxChange() {
+  const parsed = Number(priceMaxInput.value.replace(/\D/g, ''))
+  const max = Number.isFinite(parsed) && priceMaxInput.value !== '' ? parsed : props.priceRange.max
+  commitPriceToFilters([localPrice.value[0], max])
+}
+
+function commitPieceCountToFilters(newPieceCount: number[]) {
+  if (Array.isArray(newPieceCount) && newPieceCount.length === 2) {
+    emit('update:modelValue', { ...props.modelValue, pieceCount: newPieceCount as [number, number] })
+  }
+}
+
+function commitNumericAttributeToFilters(attributeId: number, newValue: number[]) {
+  if (Array.isArray(newValue) && newValue.length === 2) {
+    emit('update:modelValue', {
+      ...props.modelValue,
+      numericAttributes: {
+        ...props.modelValue.numericAttributes,
+        [attributeId]: newValue as [number, number],
+      },
+    })
+  }
+}
+
+function resetFilters() {
+  const resetNumericAttrs: Record<number, [number, number]> = {}
+  Object.entries(props.numericAttributeRanges).forEach(([attrId, range]) => {
+    resetNumericAttrs[Number(attrId)] = [range.min, range.max]
+  })
+
+  emit('update:modelValue', {
+    subCategoryIds: [],
+    pieceCount: props.pieceCountRange ? [props.pieceCountRange.min, props.pieceCountRange.max] : null,
+    price: [props.priceRange.min, props.priceRange.max],
+    brandIds: [],
+    productLineIds: [],
+    materialIds: [],
+    countryIds: [],
+    attributes: {},
+    numericAttributes: resetNumericAttrs,
+  })
+}
+
+function closeDrawer() {
+  emit('update:open', false)
+}
+
+// Синхронизация локального состояния с пропсами
+watch(() => props.modelValue.price, (newVal) => {
+  localPrice.value = [...newVal]
+  syncPriceInputs()
+}, { deep: true })
+
+watch(() => props.priceRange, (newRange) => {
+  localPrice.value = [newRange.min, newRange.max]
+  syncPriceInputs()
+}, { deep: true })
+
+watch(() => props.modelValue.pieceCount, (newVal) => {
+  localPieceCount.value = newVal ? [...newVal] : null
+}, { deep: true })
+
+watch(() => props.pieceCountRange, (newRange) => {
+  localPieceCount.value = newRange ? [newRange.min, newRange.max] : null
+}, { deep: true })
+
+watch(() => props.modelValue.numericAttributes, (newVal) => {
+  localNumericAttributes.value = newVal ? { ...newVal } : {}
+}, { deep: true })
+
+watch(() => props.numericAttributeRanges, (newRanges) => {
+  Object.entries(newRanges).forEach(([attrId, range]) => {
+    const id = Number(attrId)
+    if (!localNumericAttributes.value[id]) {
+      localNumericAttributes.value[id] = [range.min, range.max]
+    }
+  })
+}, { deep: true, immediate: true })
+
+// --- 4. UI-МЕЛОЧИ (скролл, лок скролла body) ---
+const asideRef = ref<HTMLElement | null>(null)
+const isScrolling = ref(false)
+let scrollTimeout: ReturnType<typeof setTimeout> | undefined
+
+function onDrawerScroll() {
+  isScrolling.value = true
+  clearTimeout(scrollTimeout)
+  scrollTimeout = setTimeout(() => {
+    isScrolling.value = false
+  }, 700)
+}
+
+watch(() => props.open, (isOpen) => {
+  if (!import.meta.client)
+    return
+  document.body.style.overflow = isOpen ? 'hidden' : ''
+})
+
+onUnmounted(() => {
+  if (import.meta.client)
+    document.body.style.overflow = ''
+  clearTimeout(scrollTimeout)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="mcd-overlay">
+      <div v-if="open" class="mcd-overlay" @click="closeDrawer" />
+    </Transition>
+
+    <Transition name="mcd-sheet">
+      <aside
+        v-if="open"
+        ref="asideRef"
+        class="mcd-aside"
+        :class="{ 'mcd-aside--scrolling': isScrolling }"
+        @scroll="onDrawerScroll"
+      >
+        <div class="mcd-header">
+          <span class="mcd-handle" />
+          <div class="mcd-header-row">
+            <span class="mcd-title">
+              <Icon name="lucide:sliders-horizontal" class="mcd-title-icon" />
+              Фильтры
+            </span>
+            <span class="mcd-header-actions">
+              <button v-if="hasActiveFilters" type="button" class="mcd-reset" @click="resetFilters">
+                Сбросить
+              </button>
+              <button type="button" class="mcd-close" aria-label="Закрыть" @click="closeDrawer">
+                <Icon name="lucide:x" class="mcd-close-icon" />
+              </button>
+            </span>
+          </div>
+        </div>
+
+        <!-- Подкатегории -->
+        <div v-if="subcategories.length > 0" class="mcd-card mcd-card--tight">
+          <button
+            v-for="cat in subcategories"
+            :key="cat.id"
+            type="button"
+            class="mcd-row"
+            :class="{ 'mcd-row--active': modelValue.subCategoryIds.includes(cat.id) }"
+            @click="updateSubCategory(cat.id)"
+          >
+            <span class="mcd-row-label">{{ cat.name }}</span>
+          </button>
+        </div>
+
+        <!-- Цена -->
+        <div class="mcd-card">
+          <div class="mcd-card-title">
+            Цена, ₸
+          </div>
+          <div class="mcd-price-row">
+            <input
+              v-model="priceMinInput"
+              inputmode="numeric"
+              class="mcd-price-input"
+              :placeholder="`от ${formatPrice(priceRange.min)}`"
+              @change="onPriceMinChange"
+            >
+            <input
+              v-model="priceMaxInput"
+              inputmode="numeric"
+              class="mcd-price-input"
+              :placeholder="`до ${formatPrice(priceRange.max)}`"
+              @change="onPriceMaxChange"
+            >
+          </div>
+        </div>
+
+        <!-- Количество деталей -->
+        <div v-if="pieceCountRange && localPieceCount" class="mcd-card">
+          <div class="mcd-card-title">
+            Количество деталей
+          </div>
+          <div class="mcd-slider-wrap">
+            <Slider
+              v-model="localPieceCount"
+              :min="pieceCountRange.min"
+              :max="pieceCountRange.max"
+              :step="10"
+              @value-commit="commitPieceCountToFilters"
+            />
+          </div>
+          <div class="mcd-slider-values">
+            <span>{{ localPieceCount[0] }} шт</span>
+            <span>{{ localPieceCount[1] }} шт</span>
+          </div>
+        </div>
+
+        <!-- Числовые атрибуты -->
+        <div
+          v-for="filter in numericFilters"
+          v-show="numericAttributeRanges[filter.id] && localNumericAttributes[filter.id]"
+          :key="`numeric-${filter.id}`"
+          class="mcd-card"
+        >
+          <div class="mcd-card-title">
+            {{ filter.name }}
+          </div>
+          <template v-if="numericAttributeRanges[filter.id] && localNumericAttributes[filter.id]">
+            <div class="mcd-slider-wrap">
+              <Slider
+                v-model="localNumericAttributes[filter.id]"
+                :min="numericAttributeRanges[filter.id].min"
+                :max="numericAttributeRanges[filter.id].max"
+                :step="1"
+                @value-commit="(val: number[]) => commitNumericAttributeToFilters(filter.id, val)"
+              />
+            </div>
+            <div class="mcd-slider-values">
+              <span>{{ localNumericAttributes[filter.id][0] }} {{ (filter as any).unit || '' }}</span>
+              <span>{{ localNumericAttributes[filter.id][1] }} {{ (filter as any).unit || '' }}</span>
+            </div>
+          </template>
+        </div>
+
+        <!-- Бренды -->
+        <div v-if="availableBrands.length > 0" class="mcd-card">
+          <div class="mcd-card-title">
+            Бренды
+          </div>
+          <button
+            v-for="brand in availableBrands"
+            :key="brand.id"
+            type="button"
+            class="mcd-row mcd-row--boxed"
+            :class="{ 'mcd-row--active': modelValue.brandIds.includes(brand.id) }"
+            @click="updateDirectFilter('brandIds', brand.id)"
+          >
+            <span class="mcd-box" :class="{ 'mcd-box--active': modelValue.brandIds.includes(brand.id) }">
+              <Icon v-if="modelValue.brandIds.includes(brand.id)" name="lucide:check" class="mcd-box-icon" />
+            </span>
+            <span class="mcd-row-label">{{ brand.name }}</span>
+            <span v-if="brand.products_count" class="mcd-row-count">{{ brand.products_count }}</span>
+          </button>
+        </div>
+
+        <!-- Линейки продуктов -->
+        <div v-if="availableProductLines.length > 0" class="mcd-card">
+          <div class="mcd-card-title">
+            Линейки
+          </div>
+          <button
+            v-for="line in availableProductLines"
+            :key="line.id"
+            type="button"
+            class="mcd-row mcd-row--boxed"
+            :class="{ 'mcd-row--active': modelValue.productLineIds?.includes(line.id) }"
+            @click="updateDirectFilter('productLineIds', line.id)"
+          >
+            <span class="mcd-box" :class="{ 'mcd-box--active': modelValue.productLineIds?.includes(line.id) }">
+              <Icon v-if="modelValue.productLineIds?.includes(line.id)" name="lucide:check" class="mcd-box-icon" />
+            </span>
+            <span class="mcd-row-label">{{ line.name }}</span>
+          </button>
+        </div>
+
+        <!-- Материалы -->
+        <div v-if="availableMaterials.length > 0" class="mcd-card">
+          <div class="mcd-card-title">
+            Материал
+          </div>
+          <button
+            v-for="material in availableMaterials"
+            :key="material.id"
+            type="button"
+            class="mcd-row mcd-row--boxed"
+            :class="{ 'mcd-row--active': modelValue.materialIds.includes(String(material.id)) }"
+            @click="updateDirectFilter('materialIds', material.id)"
+          >
+            <span class="mcd-box" :class="{ 'mcd-box--active': modelValue.materialIds.includes(String(material.id)) }">
+              <Icon v-if="modelValue.materialIds.includes(String(material.id))" name="lucide:check" class="mcd-box-icon" />
+            </span>
+            <span class="mcd-row-label">{{ material.name }}</span>
+          </button>
+        </div>
+
+        <!-- Страны -->
+        <div v-if="availableCountries.length > 0" class="mcd-card">
+          <div class="mcd-card-title">
+            Страна происхождения
+          </div>
+          <button
+            v-for="country in availableCountries"
+            :key="country.id"
+            type="button"
+            class="mcd-row mcd-row--boxed"
+            :class="{ 'mcd-row--active': modelValue.countryIds.includes(String(country.id)) }"
+            @click="updateDirectFilter('countryIds', country.id)"
+          >
+            <span class="mcd-box" :class="{ 'mcd-box--active': modelValue.countryIds.includes(String(country.id)) }">
+              <Icon v-if="modelValue.countryIds.includes(String(country.id))" name="lucide:check" class="mcd-box-icon" />
+            </span>
+            <span class="mcd-row-label">{{ country.name }}</span>
+          </button>
+        </div>
+
+        <!-- Динамические select-атрибуты -->
+        <div v-for="filter in checkboxFilters" :key="filter.id" class="mcd-card">
+          <div class="mcd-card-title">
+            {{ filter.name }}
+          </div>
+          <button
+            v-for="option in filter.attribute_options"
+            :key="option.id"
+            type="button"
+            class="mcd-row mcd-row--boxed"
+            :class="{ 'mcd-row--active': modelValue.attributes[filter.slug]?.includes(option.id) }"
+            @click="updateAttribute(filter.slug, option.id)"
+          >
+            <span class="mcd-box" :class="{ 'mcd-box--active': modelValue.attributes[filter.slug]?.includes(option.id) }">
+              <Icon v-if="modelValue.attributes[filter.slug]?.includes(option.id)" name="lucide:check" class="mcd-box-icon" />
+            </span>
+            <span class="mcd-row-label">{{ option.value }}</span>
+          </button>
+        </div>
+
+        <!-- Цветовые атрибуты -->
+        <div v-for="filter in colorFilters" :key="`color-${filter.id}`" class="mcd-card">
+          <div class="mcd-card-title">
+            {{ filter.name }}
+          </div>
+          <div class="mcd-color-grid">
+            <button
+              v-for="option in filter.attribute_options"
+              :key="option.id"
+              type="button"
+              class="mcd-color-item"
+              :class="{ 'mcd-color-item--active': modelValue.attributes[filter.slug]?.includes(option.id) }"
+              :title="option.value"
+              @click="updateAttribute(filter.slug, option.id)"
+            >
+              <span
+                class="mcd-color-swatch"
+                :style="{ backgroundColor: ((option.meta as unknown) as ColorOptionMeta)?.hex }"
+              />
+              <span class="mcd-color-label">{{ option.value }}</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="mcd-footer">
+          <button type="button" class="mcd-apply" @click="closeDrawer">
+            Показать товары
+          </button>
+        </div>
+      </aside>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.mcd-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: rgba(15, 23, 42, 0.44);
+}
+
+.mcd-overlay-enter-active,
+.mcd-overlay-leave-active {
+  transition: opacity 0.28s ease;
+}
+
+.mcd-overlay-enter-from,
+.mcd-overlay-leave-to {
+  opacity: 0;
+}
+
+.mcd-aside {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 90;
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(238, 240, 243, 0.8);
+  backdrop-filter: blur(26px) saturate(1.8);
+  -webkit-backdrop-filter: blur(26px) saturate(1.8);
+  border-radius: 22px 22px 0 0;
+  padding: 0 14px 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  box-shadow: 0 -18px 48px rgba(15, 23, 42, 0.22);
+  font-family: var(--font-sans);
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.mcd-aside::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+
+.mcd-aside::-webkit-scrollbar-track {
+  background: transparent;
+  margin: 10px 0;
+}
+
+.mcd-aside::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 99px;
+}
+
+.mcd-aside--scrolling {
+  scrollbar-color: rgba(100, 116, 139, 0.4) transparent;
+}
+
+.mcd-aside--scrolling::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.35);
+}
+
+.mcd-sheet-enter-active,
+.mcd-sheet-leave-active {
+  transition: transform 0.34s cubic-bezier(0.32, 0.72, 0.33, 1);
+}
+
+.mcd-sheet-enter-from,
+.mcd-sheet-leave-to {
+  transform: translateY(103%);
+}
+
+.mcd-header {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  margin: 0 -14px;
+  padding: 9px 20px 10px;
+  background: rgba(238, 240, 243, 0.72);
+  backdrop-filter: blur(18px) saturate(1.6);
+  -webkit-backdrop-filter: blur(18px) saturate(1.6);
+  border-radius: 22px 22px 0 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mcd-handle {
+  width: 40px;
+  height: 4px;
+  border-radius: 999px;
+  background: #d1d5db;
+  margin: 0 auto 10px;
+}
+
+.mcd-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mcd-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font: 800 18px var(--font-sans);
+  color: var(--foreground);
+}
+
+.mcd-title-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--primary);
+}
+
+.mcd-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.mcd-reset {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: 600 14px var(--font-sans);
+  color: var(--primary);
+  padding: 0;
+}
+
+.mcd-close {
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.95), rgba(224, 233, 247, 0.6));
+  backdrop-filter: blur(10px) saturate(1.6);
+  -webkit-backdrop-filter: blur(10px) saturate(1.6);
+  box-shadow:
+    inset 0 1px 0 #fff,
+    0 3px 10px rgba(15, 23, 42, 0.1);
+  display: grid;
+  place-content: center;
+  cursor: pointer;
+}
+
+.mcd-close-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--foreground);
+}
+
+.mcd-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 16px 16px 8px;
+}
+
+.mcd-card--tight {
+  padding: 8px;
+}
+
+.mcd-card-title {
+  font: 700 15px var(--font-sans);
+  color: var(--foreground);
+  margin-bottom: 12px;
+}
+
+.mcd-card--tight .mcd-card-title {
+  margin-bottom: 6px;
+}
+
+.mcd-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 44px;
+  padding: 0 10px;
+  border: none;
+  background: transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  font: 600 14px var(--font-sans);
+  color: var(--foreground);
+  margin-bottom: 8px;
+}
+
+.mcd-row:last-child {
+  margin-bottom: 0;
+}
+
+.mcd-row--boxed {
+  margin-bottom: 4px;
+  padding: 0 4px;
+}
+
+.mcd-row--active {
+  background: rgba(43, 127, 255, 0.12);
+  color: var(--primary);
+}
+
+.mcd-row-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mcd-row-count {
+  font: 500 12px var(--font-sans);
+  color: var(--muted-foreground);
+}
+
+.mcd-box {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 1.5px solid var(--border);
+  background: #fff;
+  display: grid;
+  place-content: center;
+}
+
+.mcd-box--active {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.mcd-box-icon {
+  width: 13px;
+  height: 13px;
+  color: #fff;
+}
+
+.mcd-price-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 16px;
+}
+
+.mcd-price-input {
+  width: 0;
+  flex: 1;
+  height: 44px;
+  padding: 0 13px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: var(--muted);
+  font: 600 14px var(--font-sans);
+  color: var(--foreground);
+  outline: none;
+}
+
+.mcd-price-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.mcd-price-input:focus {
+  border-color: var(--primary);
+  background: #fff;
+}
+
+.mcd-slider-wrap {
+  padding: 2px 4px 12px;
+}
+
+.mcd-slider-values {
+  display: flex;
+  justify-content: space-between;
+  font: 600 13px var(--font-sans);
+  color: var(--muted-foreground);
+  padding-bottom: 16px;
+}
+
+.mcd-color-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  padding-bottom: 12px;
+}
+
+.mcd-color-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.mcd-color-item--active {
+  background: rgba(43, 127, 255, 0.1);
+  box-shadow: 0 0 0 2px var(--primary) inset;
+}
+
+.mcd-color-swatch {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 2px solid var(--border);
+}
+
+.mcd-color-item--active .mcd-color-swatch {
+  border-color: var(--primary);
+}
+
+.mcd-color-label {
+  font: 500 11px var(--font-sans);
+  color: var(--foreground);
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.mcd-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  margin: 4px -14px 0;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+  background: linear-gradient(180deg, rgba(238, 240, 243, 0) 0%, rgba(238, 240, 243, 0.88) 34%);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.mcd-apply {
+  width: 100%;
+  height: 52px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: linear-gradient(150deg, rgba(77, 148, 255, 0.95), rgba(23, 101, 235, 0.85));
+  backdrop-filter: blur(12px) saturate(1.7);
+  -webkit-backdrop-filter: blur(12px) saturate(1.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    inset 0 -2px 8px rgba(6, 53, 138, 0.28),
+    0 10px 26px rgba(43, 127, 255, 0.4);
+  color: #fff;
+  font: 700 15px var(--font-sans);
+  cursor: pointer;
+}
+
+.mcd-apply:active {
+  transform: scale(0.98);
+}
+</style>

--- a/components/common/Header.vue
+++ b/components/common/Header.vue
@@ -1,8 +1,21 @@
 <script setup lang="ts">
-import type { HeaderOverlay } from '@/types/app'
-import { provide, readonly, ref } from 'vue'
+import type { CSSProperties } from 'vue'
+import type { HeaderOverlay, HeaderVariant } from '@/types/app'
+import { computed, onMounted, onUnmounted, provide, readonly, ref, toRef } from 'vue'
 import { carouselContainerVariants } from '@/lib/variants'
-import { HeaderOverlayKey } from '@/types/app'
+import { HeaderOverlayKey, HeaderVariantKey } from '@/types/app'
+
+const props = withDefaults(
+  defineProps<{
+    /**
+     * `solid`   — обычная шапка в потоке (все layout'ы, кроме главной).
+     * `overlay` — прозрачная шапка поверх героя; при скролле «схлопывается»
+     *             в стеклянную плашку с отступами (только на главной).
+     */
+    variant?: 'solid' | 'overlay'
+  }>(),
+  { variant: 'solid' },
+)
 
 const containerClass = carouselContainerVariants({ contained: 'always' })
 const isHeaderOverlayVisible = ref(false)
@@ -24,14 +37,101 @@ const overlayProvider: HeaderOverlay = {
 
 provide(HeaderOverlayKey, overlayProvider)
 
+// ---------------------------------------------------------------------------
+// Режим overlay: прозрачная шапка над героем, стекло при скролле.
+// Порог из прототипа — scrollY > высотаГероя * 0.55 (Homepage.dc.html:711).
+// Шапка в этом режиме показывается только на десктопе (обёртка hidden lg:block
+// в layouts/Home.vue), поэтому высоту героя аппроксимируем по вьюпорту:
+// на десктопе герой = clamp(560px, 80vh, 760px).
+// ---------------------------------------------------------------------------
+const SCROLLED_RATIO = 0.55
+const isScrolled = ref(false)
+
+function desktopHeroHeight(): number {
+  const vh = window.innerHeight || 760
+  return Math.min(760, Math.max(560, vh * 0.8))
+}
+
+let rafId = 0
+function onScroll() {
+  if (rafId)
+    return
+  rafId = requestAnimationFrame(() => {
+    rafId = 0
+    isScrolled.value = window.scrollY > desktopHeroHeight() * SCROLLED_RATIO
+  })
+}
+
+onMounted(() => {
+  if (props.variant !== 'overlay')
+    return
+  window.addEventListener('scroll', onScroll, { passive: true })
+  isScrolled.value = window.scrollY > desktopHeroHeight() * SCROLLED_RATIO
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll)
+  if (rafId)
+    cancelAnimationFrame(rafId)
+})
+
+// Прокидываем режим и состояние скролла потомкам (мега-меню, пилюли).
+// Потребители инжектят С ДЕФОЛТОМ, поэтому прочие layout'ы не затрагиваются.
+const headerVariantProvider: HeaderVariant = {
+  variant: readonly(toRef(props, 'variant')),
+  isScrolled: readonly(isScrolled),
+}
+provide(HeaderVariantKey, headerVariantProvider)
+
 function handleOverlayClick() {
   hideHeaderOverlay()
   desktopTabBarRef.value?.closeAllPopups()
 }
+
+const isOverlay = computed(() => props.variant === 'overlay')
+
+/**
+ * Класс корня шапки.
+ * В режиме `solid` строка ПОБАЙТОВО совпадает с прежней вёрсткой — это
+ * гарантия неизменности остальных шести layout'ов.
+ */
+const headerClass = computed(() =>
+  isOverlay.value
+    ? 'fixed left-0 right-0 top-0 z-[100]'
+    : 'relative z-50 bg-white md:bg-blue-500 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800',
+)
+
+/** Динамический inline-стиль стеклянного состояния (Homepage.dc.html:920). */
+const overlayStyle = computed<CSSProperties>(() => {
+  if (!isOverlay.value)
+    return {}
+  const scrolled = isScrolled.value
+  return {
+    padding: '14px 0',
+    // НЕ overflow:hidden: мега-меню AppTabBar рендерится ВНУТРИ шапки и было бы
+    // обрезано. Скруглённое стекло рисуется фоном, контент отступает от углов.
+    overflow: 'visible',
+    top: scrolled ? '12px' : '0',
+    left: scrolled ? '12px' : '0',
+    right: scrolled ? '12px' : '0',
+    borderRadius: scrolled ? '22px' : '0',
+    background: scrolled
+      ? 'color-mix(in srgb, var(--header-bg) 66%, transparent)'
+      : 'transparent',
+    backdropFilter: scrolled ? 'blur(18px) saturate(1.5)' : 'none',
+    WebkitBackdropFilter: scrolled ? 'blur(18px) saturate(1.5)' : 'none',
+    border: scrolled
+      ? '1px solid rgba(255,255,255,.22)'
+      : '1px solid transparent',
+    boxShadow: scrolled ? '0 10px 30px rgba(15,23,42,.2)' : 'none',
+    transition:
+      'top .25s ease, left .25s ease, right .25s ease, border-radius .25s ease, background .25s ease, box-shadow .25s ease, backdrop-filter .25s ease',
+  }
+})
 </script>
 
 <template>
-  <header class="relative z-50 bg-white md:bg-blue-500 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+  <header :class="headerClass" :style="overlayStyle">
     <!-- <CommonHeaderTop :class="containerClass" /> -->
     <div :class="containerClass">
       <CommonHeaderBottom />

--- a/components/common/SiteHeader.vue
+++ b/components/common/SiteHeader.vue
@@ -1,0 +1,536 @@
+<script setup lang="ts">
+import type { CSSProperties } from 'vue'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useProfileStore } from '@/stores/core/profileStore'
+import { useAuthStore } from '@/stores/core/useAuthStore'
+import { useModalStore } from '@/stores/modal/useModalStore'
+import { useCartStore } from '@/stores/publicStore/cartStore'
+import { useWishlistStore } from '@/stores/publicStore/wishlistStore'
+
+/**
+ * Шапка витрины — порт SiteHeader.dc.html.
+ *
+ * Одна строка: логотип · «Каталог» · строка поиска · избранное · корзина ·
+ * вход/аккаунт. Кнопка «Каталог» открывает мега-меню с рельсом 274px.
+ *
+ * `variant`:
+ *  - `overlay` — прозрачная поверх героя (главная), стекло при скролле за герой;
+ *  - `solid`   — плашка цвета `--header-bg` (каталог/внутренние), стекло при
+ *                скролле > 8px. В обоих режимах шапка `position:fixed`, а место
+ *                под неё резервирует распорка (только `solid`).
+ *
+ * `sticky` (default `true`): когда `false`, шапка рендерится в потоке
+ * (`position:static`, без распорки и без стекла-при-скролле) и просто
+ * уезжает вместе со страницей — используется на `catalog-listing`, где
+ * единственный элемент, который должен "прилипать" при скролле, это
+ * `CategoryScrollBar`, а не сама шапка.
+ *
+ * Десктоп-строка живёт на ≥lg; на <lg — компактная плашка (нужна только там,
+ * где макет не прячет шапку, т.е. Internal). Прочие витринные макеты прячут
+ * шапку на мобильном своей обёрткой и оставляют собственный мобильный хедер.
+ */
+const props = withDefaults(
+  defineProps<{ variant?: 'overlay' | 'solid', sticky?: boolean }>(),
+  { variant: 'solid', sticky: true },
+)
+
+const authStore = useAuthStore()
+const profileStore = useProfileStore()
+const wishlistStore = useWishlistStore()
+const cartStore = useCartStore()
+const modalStore = useModalStore()
+const route = useRoute()
+
+const { user, isLoggedIn: isAuth } = storeToRefs(authStore)
+const { fullName, bonusBalance } = storeToRefs(profileStore)
+
+const wishlistCount = computed(() => wishlistStore.wishlistProductIds.length)
+const cartCount = computed(() => cartStore.items.length)
+const userInitial = computed(() => fullName.value?.charAt(0).toUpperCase() || 'П')
+const formattedBonus = computed(() => (bonusBalance.value ?? 0).toLocaleString('ru-KZ'))
+
+const isOverlay = computed(() => props.variant === 'overlay')
+
+// ---------------------------------------------------------------------------
+// Стекло при скролле.
+// overlay — порог завязан на высоту героя (как в прежней шапке главной,
+// clamp(560, 80vh, 760) * 0.55); solid — простой порог из прототипа (>8px).
+// ---------------------------------------------------------------------------
+const isScrolled = ref(false)
+
+function scrolledThreshold(): number {
+  if (isOverlay.value) {
+    const vh = window.innerHeight || 760
+    return Math.min(760, Math.max(560, vh * 0.8)) * 0.55
+  }
+  return 8
+}
+
+let rafId = 0
+function onScroll() {
+  if (rafId)
+    return
+  rafId = requestAnimationFrame(() => {
+    rafId = 0
+    const next = window.scrollY > scrolledThreshold()
+    if (next !== isScrolled.value)
+      isScrolled.value = next
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Мега-меню «Каталог».
+// ---------------------------------------------------------------------------
+const catalogOpen = ref(false)
+const catalogBtn = ref<HTMLButtonElement | null>(null)
+function toggleCatalog() {
+  catalogOpen.value = !catalogOpen.value
+}
+function closeCatalog() {
+  catalogOpen.value = false
+}
+function onKeydown(e: KeyboardEvent) {
+  // Esc закрывает каталог и возвращает фокус на кнопку-переключатель.
+  if (e.key === 'Escape' && catalogOpen.value) {
+    closeCatalog()
+    catalogBtn.value?.focus()
+  }
+}
+
+// Закрываем каталог при навигации.
+watch(() => route.fullPath, closeCatalog)
+
+onMounted(() => {
+  if (props.sticky) {
+    window.addEventListener('scroll', onScroll, { passive: true })
+    isScrolled.value = window.scrollY > scrolledThreshold()
+  }
+  window.addEventListener('keydown', onKeydown)
+  if (user.value)
+    profileStore.loadProfile()
+})
+
+onUnmounted(() => {
+  if (props.sticky)
+    window.removeEventListener('scroll', onScroll)
+  window.removeEventListener('keydown', onKeydown)
+  if (rafId)
+    cancelAnimationFrame(rafId)
+})
+
+function openLogin() {
+  modalStore.openLoginModal()
+}
+
+const wrapStyle = computed<CSSProperties>(() => {
+  if (!props.sticky) {
+    return {
+      position: 'static',
+      zIndex: 100,
+      background: 'var(--header-bg)',
+      border: '1px solid transparent',
+    }
+  }
+
+  const scrolled = isScrolled.value
+  const tTop = isOverlay.value
+  return {
+    position: 'fixed',
+    zIndex: 100,
+    top: scrolled ? '12px' : '0',
+    left: scrolled ? '12px' : '0',
+    right: scrolled ? '12px' : '0',
+    borderRadius: scrolled ? '22px' : '0',
+    overflow: 'hidden',
+    transition:
+      'top .25s ease, left .25s ease, right .25s ease, border-radius .25s ease, background .25s ease, box-shadow .25s ease, backdrop-filter .25s ease',
+    background: scrolled
+      ? 'color-mix(in srgb, var(--header-bg) 66%, transparent)'
+      : (tTop ? 'transparent' : 'var(--header-bg)'),
+    backdropFilter: scrolled ? 'blur(18px) saturate(1.5)' : 'none',
+    WebkitBackdropFilter: scrolled ? 'blur(18px) saturate(1.5)' : 'none',
+    border: scrolled ? '1px solid rgba(255,255,255,.22)' : '1px solid transparent',
+    boxShadow: scrolled ? '0 10px 30px rgba(15,23,42,.2)' : 'none',
+  }
+})
+</script>
+
+<template>
+  <div>
+    <!-- ============ ДЕСКТОП (≥lg) ============ -->
+    <div class="hidden lg:block">
+      <!-- Распорка под fixed-шапку (только solid+sticky; overlay парит над героем, non-sticky не fixed вовсе). -->
+      <div v-if="!isOverlay && sticky" class="sh-spacer" />
+
+      <div :class="{ 'max-w-screen-2xl mx-auto': isOverlay && isScrolled }" :style="wrapStyle">
+        <header class="sh-header">
+          <div class="sh-row app-container">
+            <!-- Логотип -->
+            <NuxtLink to="/" class="sh-logo" aria-label="Ухтышка — на главную">
+              <span class="sh-logo__badge">
+                <svg viewBox="11 0 64 78" width="26" height="31" aria-hidden="true">
+                  <g transform="translate(2 0)"><g transform="rotate(-9 42 72)">
+                    <rect x="37.5" y="4" width="9" height="13" rx="4.5" fill="#fff" />
+                    <rect x="34" y="15.5" width="16" height="5.5" rx="2.75" fill="rgba(255,255,255,.65)" />
+                    <path d="M16 36 C16 22.5 68 22.5 68 36 L68 36.5 C68 40.6 64.6 44 60.5 44 L23.5 44 C19.4 44 16 40.6 16 36.5 Z" fill="#fff" />
+                    <rect x="20" y="46.5" width="44" height="6" rx="3" fill="#ffd34d" />
+                    <path d="M23 55 L61 55 C57.5 61.5 50 64 45 70 A3.8 3.8 0 0 1 39 70 C34 64 26.5 61.5 23 55 Z" fill="#ff8ac2" />
+                  </g></g>
+                </svg>
+              </span>
+              <span class="sh-logo__word">Ухтышка</span>
+            </NuxtLink>
+
+            <!-- Каталог -->
+            <button
+              ref="catalogBtn"
+              type="button"
+              class="sh-cat"
+              :class="{ 'sh-cat--open': catalogOpen }"
+              :aria-expanded="catalogOpen"
+              aria-controls="sh-catalog-panel"
+              aria-haspopup="true"
+              @click="toggleCatalog"
+            >
+              <Icon :name="catalogOpen ? 'lucide:x' : 'lucide:layout-grid'" class="size-5" />
+              <span>Каталог</span>
+            </button>
+
+            <!-- Поиск -->
+            <CommonSiteHeaderSearch />
+
+            <!-- Избранное -->
+            <NuxtLink to="/profile/wishlist" class="sh-icon-btn" aria-label="Избранное">
+              <Icon name="line-md:heart" class="size-[22px]" mode="svg" />
+              <ClientOnly>
+                <span v-if="wishlistCount > 0" class="sh-badge">{{ wishlistCount > 9 ? '9+' : wishlistCount }}</span>
+              </ClientOnly>
+            </NuxtLink>
+
+            <!-- Корзина -->
+            <NuxtLink to="/cart" class="sh-icon-btn" aria-label="Корзина">
+              <Icon name="solar:cart-3-bold" class="size-[22px]" mode="svg" />
+              <ClientOnly>
+                <span v-if="cartCount > 0" class="sh-badge">{{ cartCount > 9 ? '9+' : cartCount }}</span>
+              </ClientOnly>
+            </NuxtLink>
+
+            <!-- Вход / аккаунт -->
+            <ClientOnly>
+              <NuxtLink v-if="isAuth" to="/profile" class="sh-account">
+                <span class="sh-account__avatar">{{ userInitial }}</span>
+                <span class="sh-account__meta">
+                  <span class="sh-account__name">{{ fullName }}</span>
+                  <span class="sh-account__bonus">
+                    <Icon name="lucide:coins" class="size-3" />
+                    {{ formattedBonus }} ₸
+                  </span>
+                </span>
+              </NuxtLink>
+              <button v-else type="button" class="sh-login" @click="openLogin">
+                <Icon name="lucide:user" class="size-[18px]" />
+                Войти
+              </button>
+
+              <template #fallback>
+                <div class="sh-account sh-account--skeleton">
+                  <span class="sh-account__avatar sh-account__avatar--skeleton" />
+                  <span class="sh-account__meta">
+                    <span class="sh-skel sh-skel--name" />
+                    <span class="sh-skel sh-skel--bonus" />
+                  </span>
+                </div>
+              </template>
+            </ClientOnly>
+          </div>
+        </header>
+      </div>
+
+      <CommonSiteHeaderMegaMenu :open="catalogOpen" @close="closeCatalog" />
+    </div>
+
+    <!-- ============ МОБИЛЬНАЯ ПЛАШКА (<lg) ============ -->
+    <div class="flex lg:hidden sh-mobile">
+      <NuxtLink to="/" class="sh-mobile__logo" aria-label="Ухтышка — на главную">
+        <svg viewBox="11 0 64 78" width="22" height="27" aria-hidden="true">
+          <g transform="translate(2 0)"><g transform="rotate(-9 42 72)">
+            <rect x="37.5" y="4" width="9" height="13" rx="4.5" fill="#fff" />
+            <rect x="34" y="15.5" width="16" height="5.5" rx="2.75" fill="rgba(255,255,255,.65)" />
+            <path d="M16 36 C16 22.5 68 22.5 68 36 L68 36.5 C68 40.6 64.6 44 60.5 44 L23.5 44 C19.4 44 16 40.6 16 36.5 Z" fill="#fff" />
+            <rect x="20" y="46.5" width="44" height="6" rx="3" fill="#ffd34d" />
+            <path d="M23 55 L61 55 C57.5 61.5 50 64 45 70 A3.8 3.8 0 0 1 39 70 C34 64 26.5 61.5 23 55 Z" fill="#ff8ac2" />
+          </g></g>
+        </svg>
+      </NuxtLink>
+
+      <CommonSiteHeaderSearch dense />
+
+      <NuxtLink to="/profile/wishlist" class="sh-mobile__btn" aria-label="Избранное">
+        <Icon name="line-md:heart" class="size-[19px]" mode="svg" />
+        <ClientOnly>
+          <span v-if="wishlistCount > 0" class="sh-mobile__dot" />
+        </ClientOnly>
+      </NuxtLink>
+      <NuxtLink to="/cart" class="sh-mobile__btn" aria-label="Корзина">
+        <Icon name="solar:cart-3-bold" class="size-[19px]" mode="svg" />
+        <ClientOnly>
+          <span v-if="cartCount > 0" class="sh-mobile__dot" />
+        </ClientOnly>
+      </NuxtLink>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sh-spacer {
+  height: 74px;
+}
+
+.sh-header {
+  padding: 14px 0;
+}
+
+.sh-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* ---- Логотип ---- */
+.sh-logo {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.sh-logo__badge {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: rgb(255 255 255 / 0.2);
+  border: 1px solid rgb(255 255 255 / 0.3);
+  display: grid;
+  place-content: center;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.sh-logo__word {
+  font: 800 22px var(--font-display);
+  color: #fff;
+  letter-spacing: -0.02em;
+}
+
+/* ---- Общая «стеклянная» кнопка (Каталог / иконки) ---- */
+.sh-cat,
+.sh-icon-btn {
+  flex: none;
+  border: 1px solid rgb(255 255 255 / 0.42);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.45),
+    0 4px 14px rgb(0 40 120 / 0.18);
+  color: #fff;
+  cursor: pointer;
+  backdrop-filter: blur(14px) saturate(1.6);
+  -webkit-backdrop-filter: blur(14px) saturate(1.6);
+  background: linear-gradient(150deg, rgb(255 255 255 / 0.3), rgb(255 255 255 / 0.12));
+  transition: background 0.2s ease;
+}
+
+.sh-cat:hover,
+.sh-icon-btn:hover,
+.sh-cat--open {
+  background: linear-gradient(150deg, rgb(255 255 255 / 0.42), rgb(255 255 255 / 0.2));
+}
+
+.sh-cat {
+  height: 46px;
+  padding: 0 18px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 600 14px var(--font-sans);
+}
+
+.sh-icon-btn {
+  position: relative;
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  display: grid;
+  place-content: center;
+  text-decoration: none;
+}
+
+.sh-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #fff;
+  font: 700 11px var(--font-sans);
+  display: grid;
+  place-content: center;
+  border: 2px solid #fff;
+}
+
+/* ---- Вход ---- */
+.sh-login {
+  flex: none;
+  height: 46px;
+  padding: 0 18px;
+  border-radius: 999px;
+  background: linear-gradient(150deg, rgb(255 255 255 / 0.98), rgb(255 255 255 / 0.75));
+  color: var(--foreground);
+  font: 700 14px var(--font-sans);
+  border: 1px solid rgb(255 255 255 / 0.9);
+  cursor: pointer;
+  backdrop-filter: blur(12px) saturate(1.6);
+  -webkit-backdrop-filter: blur(12px) saturate(1.6);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 1),
+    0 6px 18px rgb(0 40 120 / 0.22);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: box-shadow 0.2s ease;
+}
+
+.sh-login:hover {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 1),
+    0 8px 22px rgb(0 40 120 / 0.3);
+}
+
+/* ---- Аккаунт ---- */
+.sh-account {
+  flex: none;
+  height: 46px;
+  padding: 0 14px 0 6px;
+  border-radius: 999px;
+  background: #fff;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 0.12);
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  text-decoration: none;
+  transition: box-shadow 0.2s ease;
+}
+
+.sh-account:hover {
+  box-shadow: 0 6px 16px rgb(15 23 42 / 0.18);
+}
+
+.sh-account__avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #9333ea, #db2777);
+  color: #fff;
+  display: grid;
+  place-content: center;
+  font: 700 14px var(--font-sans);
+}
+
+.sh-account__meta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.12;
+  text-align: left;
+}
+
+.sh-account__name {
+  font: 600 13px var(--font-sans);
+  color: var(--foreground);
+  max-width: 130px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sh-account__bonus {
+  font: 700 12px var(--font-sans);
+  color: var(--bonus);
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+/* ---- Скелетон аккаунта (SSR/до гидрации) ---- */
+.sh-account--skeleton {
+  cursor: default;
+}
+.sh-account__avatar--skeleton {
+  background: var(--muted);
+}
+.sh-skel {
+  display: block;
+  border-radius: 5px;
+  background: var(--muted);
+}
+.sh-skel--name {
+  width: 76px;
+  height: 11px;
+  margin-bottom: 4px;
+}
+.sh-skel--bonus {
+  width: 48px;
+  height: 10px;
+}
+
+/* ============ Мобильная плашка ============ */
+.sh-mobile {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--header-bg);
+}
+
+.sh-mobile__logo {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  background: rgb(255 255 255 / 0.18);
+  border: 1px solid rgb(255 255 255 / 0.28);
+  display: grid;
+  place-content: center;
+}
+
+.sh-mobile__btn {
+  flex: none;
+  position: relative;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-content: center;
+  color: #fff;
+  background: rgb(255 255 255 / 0.16);
+  border: 1px solid rgb(255 255 255 / 0.24);
+}
+
+.sh-mobile__dot {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #f97316;
+  border: 2px solid var(--header-bg);
+}
+</style>

--- a/components/common/SiteHeaderMegaMenu.vue
+++ b/components/common/SiteHeaderMegaMenu.vue
@@ -1,0 +1,430 @@
+<script setup lang="ts">
+import type { CategoryMenuItem } from '@/types'
+import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
+import { BUCKET_NAME_CATEGORY } from '@/constants'
+import { useCategoriesStore } from '@/stores/publicStore/categoriesStore'
+
+/**
+ * Мега-меню «Каталог» (SiteHeader.dc.html — панель с рельсом 274px).
+ *
+ * Слева — рельс корневых категорий (переключение по наведению/клику),
+ * справа — группы (2-й уровень) с сеткой карточек-картинок (3-й уровень).
+ * Данные — реальные из `categoriesStore.menuTree`, поэтому структура
+ * адаптивна: у листовой категории 2-го уровня показываем её саму карточкой.
+ *
+ * Панель телепортируется в body и лежит НИЖЕ шапки (z:99 < шапка z:100),
+ * чтобы кнопка-переключатель «Каталог/✕» оставалась кликабельной.
+ */
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{ close: [] }>()
+
+const categoriesStore = useCategoriesStore()
+const { getVariantUrl } = useSupabaseStorage()
+
+const menuTree = computed(() => categoriesStore.menuTree)
+const activeIndex = ref(0)
+
+// Тёплые пастельные подложки карточек — по корневой категории (как в прототипе).
+const TINTS = ['#dff0ff', '#ffe9f3', '#fff3d9', '#e6f7e9', '#f1e9ff', '#e0f5f7']
+const tint = computed(() => TINTS[activeIndex.value % TINTS.length])
+const cardStyle = computed(() => ({
+  background: `linear-gradient(165deg, color-mix(in oklch, ${tint.value} 55%, #fff), ${tint.value})`,
+}))
+
+const activeRoot = computed<CategoryMenuItem | undefined>(() => menuTree.value[activeIndex.value])
+
+interface MegaItem { id: string, name: string, href: string, image: string | null, showCaption: boolean }
+interface MegaGroup { id: string, name: string, href: string, items: MegaItem[] }
+
+const groups = computed<MegaGroup[]>(() => {
+  const root = activeRoot.value
+  if (!root?.children?.length)
+    return []
+  return root.children.map((l2) => {
+    const kids = l2.children ?? []
+    const hasKids = kids.length > 0
+    const source = hasKids ? kids : [l2]
+    return {
+      id: l2.id,
+      name: l2.name,
+      href: l2.href,
+      items: source.map(it => ({
+        id: it.id,
+        name: it.name,
+        href: it.href,
+        image: catImage(it.image_url),
+        showCaption: hasKids,
+      })),
+    }
+  })
+})
+
+function catImage(url: string | null): string | null {
+  return url ? getVariantUrl(BUCKET_NAME_CATEGORY, url, 'sm') : null
+}
+
+function railThumb(root: CategoryMenuItem): string | null {
+  return catImage(root.image_url)
+}
+
+const panelRef = ref<HTMLElement | null>(null)
+
+onMounted(() => {
+  // Идемпотентно: стор не перезапрашивает, если данные уже есть.
+  categoriesStore.fetchCategoryData()
+})
+
+// Между открытиями сохраняем последнюю активную категорию (как в прототипе);
+// на первую сбрасываем ТОЛЬКО если индекс вышел за пределы дерева. При открытии
+// переносим фокус в панель — иначе клавиатурный юзер остаётся на кнопке.
+watch(() => props.open, (isOpen) => {
+  if (!isOpen)
+    return
+  if (activeIndex.value >= menuTree.value.length)
+    activeIndex.value = 0
+  categoriesStore.fetchCategoryData()
+  nextTick(() => panelRef.value?.querySelector<HTMLElement>('.sh-rail')?.focus())
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="sh-scrim">
+      <div v-if="open" class="sh-scrim" @click="emit('close')" />
+    </Transition>
+
+    <Transition name="sh-mega">
+      <div v-if="open" id="sh-catalog-panel" ref="panelRef" class="sh-mega" role="group" aria-label="Каталог товаров">
+        <!-- Рельс корневых категорий -->
+        <div class="sh-mega__rail">
+          <button
+            v-for="(root, i) in menuTree"
+            :key="root.id"
+            type="button"
+            class="sh-rail"
+            :class="{ 'sh-rail--active': i === activeIndex }"
+            @mouseenter="activeIndex = i"
+            @focus="activeIndex = i"
+            @click="activeIndex = i"
+          >
+            <span class="sh-rail__icon">
+              <Icon v-if="root.icon_name" :name="root.icon_name" class="size-5" />
+              <img v-else-if="railThumb(root)" :src="railThumb(root)!" :alt="root.name" class="sh-rail__thumb" loading="lazy">
+              <Icon v-else name="lucide:shapes" class="size-5" />
+            </span>
+            <span class="sh-rail__name">{{ root.name }}</span>
+            <Icon v-if="i === activeIndex" name="lucide:chevron-right" class="size-4 shrink-0 opacity-60" />
+          </button>
+
+          <div v-if="!menuTree.length" class="sh-rail__skeleton">
+            <div v-for="n in 6" :key="n" class="sh-rail__skeleton-row" />
+          </div>
+        </div>
+
+        <!-- Контент активной категории -->
+        <div class="sh-mega__content">
+          <NuxtLink
+            v-if="activeRoot"
+            :to="activeRoot.href"
+            class="sh-mega__title"
+            @click="emit('close')"
+          >
+            {{ activeRoot.name }}
+            <Icon name="lucide:arrow-right" class="size-5 opacity-50" />
+          </NuxtLink>
+
+          <div v-for="group in groups" :key="group.id" class="sh-group">
+            <NuxtLink :to="group.href" class="sh-group__title" @click="emit('close')">
+              {{ group.name }}
+              <Icon name="lucide:chevron-right" class="size-[15px] opacity-50" />
+            </NuxtLink>
+            <div class="sh-group__grid">
+              <NuxtLink
+                v-for="item in group.items"
+                :key="item.id"
+                :to="item.href"
+                class="sh-card-link"
+                @click="emit('close')"
+              >
+                <span class="sh-card" :style="cardStyle">
+                  <img
+                    v-if="item.image"
+                    :src="item.image"
+                    :alt="item.name"
+                    class="sh-card__img"
+                    loading="lazy"
+                    decoding="async"
+                  >
+                  <Icon v-else name="lucide:image" class="size-7 text-muted-foreground/40" />
+                </span>
+                <span v-if="item.showCaption" class="sh-card__caption">{{ item.name }}</span>
+              </NuxtLink>
+            </div>
+          </div>
+
+          <div v-if="menuTree.length && !groups.length" class="sh-mega__empty">
+            <Icon name="lucide:package-open" class="size-10 text-muted-foreground/50" />
+            <p>В этой категории пока нет подкатегорий</p>
+          </div>
+          <div v-else-if="!menuTree.length" class="sh-mega__empty">
+            <Icon name="lucide:loader-2" class="size-6 animate-spin text-primary" />
+            <p>Загружаем каталог…</p>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.sh-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 98;
+  background: rgb(15 23 42 / 0.42);
+}
+
+.sh-mega {
+  position: fixed;
+  top: 88px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(1160px, 94vw);
+  height: min(80vh, 720px);
+  z-index: 99;
+  background: var(--popover);
+  border-radius: 20px;
+  box-shadow: 0 30px 70px rgb(15 23 42 / 0.28);
+  overflow: hidden;
+  display: flex;
+}
+
+/* ---- Рельс ---- */
+.sh-mega__rail {
+  width: 274px;
+  flex: none;
+  border-right: 1px solid var(--border);
+  padding: 16px 12px;
+  overflow-y: auto;
+  background: color-mix(in oklch, var(--muted) 40%, var(--popover));
+}
+
+.sh-rail {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 14px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 12px;
+  text-align: left;
+  color: var(--foreground);
+  font: 600 15px var(--font-sans);
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.sh-rail--active {
+  background: var(--brand-surface);
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.sh-rail__icon {
+  flex: none;
+  display: grid;
+  place-content: center;
+  width: 28px;
+  height: 28px;
+}
+
+.sh-rail__thumb {
+  width: 26px;
+  height: 26px;
+  object-fit: contain;
+  mix-blend-mode: multiply;
+}
+
+.sh-rail__name {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sh-rail__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sh-rail__skeleton-row {
+  height: 44px;
+  border-radius: 12px;
+  background: var(--muted);
+  animation: sh-pulse 1.2s ease-in-out infinite;
+}
+
+/* ---- Контент ---- */
+.sh-mega__content {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 22px 30px 30px;
+}
+
+.sh-mega__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 4px;
+  font: 700 24px var(--font-sans);
+  letter-spacing: -0.02em;
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.sh-mega__title:hover {
+  color: var(--primary);
+}
+
+.sh-group {
+  margin-top: 22px;
+}
+
+.sh-group__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 0 13px;
+  font: 700 16px var(--font-sans);
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.sh-group__title:hover {
+  color: var(--primary);
+}
+
+.sh-group__grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 18px 16px;
+}
+
+@media (max-width: 1100px) {
+  .sh-group__grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.sh-card-link {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-decoration: none;
+  transition: transform 0.15s ease;
+}
+
+.sh-card-link:hover {
+  transform: translateY(-3px);
+}
+
+.sh-card {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1.2;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 0.75);
+  box-shadow:
+    inset 0 1.5px 0 rgb(255 255 255 / 0.9),
+    inset 0 -12px 20px rgb(15 23 42 / 0.07),
+    0 6px 16px rgb(15 23 42 / 0.09);
+}
+
+.sh-card__img {
+  width: 82%;
+  height: 82%;
+  object-fit: contain;
+  mix-blend-mode: multiply;
+}
+
+.sh-card__caption {
+  font: 600 13px var(--font-sans);
+  color: var(--foreground);
+  line-height: 1.25;
+}
+
+.sh-mega__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 60px 0;
+  color: var(--muted-foreground);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+/* ---- Анимации ---- */
+.sh-scrim-enter-active,
+.sh-scrim-leave-active {
+  transition: opacity 0.22s ease;
+}
+.sh-scrim-enter-from,
+.sh-scrim-leave-to {
+  opacity: 0;
+}
+
+.sh-mega-enter-active {
+  transition:
+    opacity 0.28s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.sh-mega-leave-active {
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+.sh-mega-enter-from,
+.sh-mega-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(-14px) scale(0.985);
+}
+
+@keyframes sh-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sh-mega-enter-active,
+  .sh-mega-leave-active {
+    transition: opacity 0.2s ease;
+  }
+  .sh-mega-enter-from,
+  .sh-mega-leave-to {
+    transform: translateX(-50%);
+  }
+  .sh-card-link:hover {
+    transform: none;
+  }
+}
+
+:global(.dark) .sh-rail__thumb,
+:global(.dark) .sh-card__img {
+  mix-blend-mode: normal;
+}
+</style>

--- a/components/common/SiteHeaderSearch.vue
+++ b/components/common/SiteHeaderSearch.vue
@@ -1,0 +1,513 @@
+<script setup lang="ts">
+import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
+import { IMAGE_SIZES } from '@/config/images'
+import { BUCKET_NAME_PRODUCT } from '@/constants'
+
+/**
+ * Инлайн-строка поиска шапки (SiteHeader.dc.html — <form> поиска).
+ *
+ * Поле ввода видно всегда, живые результаты падают в выпадашку (Popover,
+ * телепортируется в body — не обрезается `overflow:hidden` стеклянной шапки).
+ * Логика поиска — общий композабл `useProductSearch`, поведение бэкенда то же.
+ *
+ * Доступность: паттерн combobox + listbox. Стрелками ↑/↓ ходим по опциям,
+ * Enter выбирает подсвеченную (или отправляет сырой запрос), Esc закрывает.
+ *
+ * `dense` — компактный вид для мобильной плашки.
+ * `showSubmitButton` — видимая кнопка «Найти» справа внутри поля (по
+ * умолчанию нет: форма и так отправляется по Enter). Только для потребителей,
+ * которым явно нужен CTA — сейчас это CategoryScrollBar.
+ */
+withDefaults(defineProps<{ dense?: boolean, showSubmitButton?: boolean }>(), {
+  dense: false,
+  showSubmitButton: false,
+})
+
+const LISTBOX_ID = useId()
+
+const open = ref(false)
+const activeIndex = ref(-1)
+
+const {
+  searchQuery,
+  searchResults,
+  isSearching,
+  suggestions,
+  hasResults,
+  hasQuery,
+  brandSuggestions,
+  debouncedSearch,
+  performSearch,
+  selectSuggestion,
+  clearSearchHistory,
+  removeHistoryItem,
+} = useProductSearch()
+
+const { getImageUrl } = useSupabaseStorage()
+
+// Живой поиск при вводе (порог как в AppTabBar — от 3 символов).
+watch(searchQuery, (q) => {
+  if (q.trim().length >= 3) {
+    debouncedSearch(q)
+  }
+  else {
+    // Чистим ОБА набора — иначе устаревшие чипы брендов держат ветку
+    // результатов и прячут панель истории.
+    searchResults.value = []
+    brandSuggestions.value = []
+  }
+})
+
+const brandOptions = computed(() =>
+  brandSuggestions.value.map(b => ({ id: `${LISTBOX_ID}-b-${b.id}`, kind: 'brand' as const, to: `/brand/${b.slug}` })),
+)
+const productOptions = computed(() =>
+  searchResults.value.slice(0, 6).map(p => ({ id: `${LISTBOX_ID}-p-${p.id}`, kind: 'product' as const, to: `/catalog/products/${p.slug}` })),
+)
+const suggestionOptions = computed(() =>
+  suggestions.value.map((s, i) => ({ id: `${LISTBOX_ID}-s-${i}`, kind: 'suggestion' as const, text: s.text })),
+)
+
+// Плоский список опций в порядке отрисовки — модель навигации клавиатурой.
+const navItems = computed(() => {
+  if (isSearching.value)
+    return []
+  if (hasResults.value || brandSuggestions.value.length > 0)
+    return [...brandOptions.value, ...productOptions.value]
+  if (hasQuery.value)
+    return []
+  return suggestionOptions.value
+})
+
+const activeId = computed(() => navItems.value[activeIndex.value]?.id)
+
+function isActive(id: string): boolean {
+  return activeId.value === id
+}
+
+// Список опций сменился — снимаем подсветку.
+watch(navItems, () => {
+  activeIndex.value = -1
+})
+
+// Подсвеченную опцию держим в зоне видимости выпадашки.
+watch(activeId, (id) => {
+  if (!id)
+    return
+  nextTick(() => document.getElementById(id)?.scrollIntoView({ block: 'nearest' }))
+})
+
+function activateItem(item: (typeof navItems.value)[number]) {
+  if (item.kind === 'suggestion') {
+    pickSuggestion(item.text)
+  }
+  else {
+    open.value = false
+    navigateTo(item.to)
+  }
+}
+
+function onKeydown(e: KeyboardEvent) {
+  const items = navItems.value
+  if (e.key === 'ArrowDown') {
+    open.value = true
+    if (items.length) {
+      e.preventDefault()
+      activeIndex.value = (activeIndex.value + 1) % items.length
+    }
+  }
+  else if (e.key === 'ArrowUp') {
+    if (items.length) {
+      e.preventDefault()
+      activeIndex.value = activeIndex.value <= 0 ? items.length - 1 : activeIndex.value - 1
+    }
+  }
+  else if (e.key === 'Enter') {
+    const item = items[activeIndex.value]
+    if (item) {
+      // Гасим неявную отправку формы — выбираем подсвеченную опцию.
+      e.preventDefault()
+      activateItem(item)
+    }
+    // Иначе форма отправится штатно → submitSearch (сырой запрос).
+  }
+  else if (e.key === 'Escape') {
+    open.value = false
+    activeIndex.value = -1
+  }
+}
+
+function submitSearch() {
+  if (!hasQuery.value)
+    return
+  performSearch()
+  open.value = false
+}
+
+function pickSuggestion(text: string) {
+  selectSuggestion(text)
+  open.value = false
+}
+
+function showAll() {
+  performSearch()
+  open.value = false
+}
+
+function onRemoveHistory(text: string, event: Event) {
+  event.stopPropagation()
+  removeHistoryItem(text)
+}
+
+function productImageUrl(url: string | null | undefined): string | null {
+  if (!url)
+    return null
+  return getImageUrl(BUCKET_NAME_PRODUCT, url, {
+    width: IMAGE_SIZES.THUMBNAIL.width,
+    height: IMAGE_SIZES.THUMBNAIL.height,
+    quality: 80,
+    format: 'webp',
+    resize: 'cover',
+  })
+}
+
+function formatPrice(price: number, discount?: number) {
+  const original = price.toLocaleString('ru-RU')
+  const hasDiscount = !!discount && discount > 0
+  const final = hasDiscount
+    ? Math.round(price * (1 - discount / 100)).toLocaleString('ru-RU')
+    : original
+  return { original, final, hasDiscount }
+}
+</script>
+
+<template>
+  <Popover v-model:open="open">
+    <PopoverAnchor as-child>
+      <form
+        class="sh-search"
+        :class="{ 'sh-search--dense': dense, 'sh-search--with-submit': showSubmitButton }"
+        role="search"
+        @submit.prevent="submitSearch"
+      >
+        <Icon name="lucide:search" class="sh-search__icon" />
+        <input
+          v-model="searchQuery"
+          type="search"
+          role="combobox"
+          aria-autocomplete="list"
+          :aria-expanded="open"
+          :aria-controls="LISTBOX_ID"
+          :aria-activedescendant="activeId || undefined"
+          enterkeyhint="search"
+          :placeholder="dense ? 'Поиск' : 'Найти игрушки, бренды, наборы…'"
+          class="sh-search__input"
+          aria-label="Поиск товаров"
+          @focus="open = true"
+          @keydown="onKeydown"
+        >
+        <button
+          v-if="hasQuery"
+          type="button"
+          class="sh-search__clear"
+          aria-label="Очистить"
+          @click="searchQuery = ''"
+        >
+          <Icon name="lucide:x" class="size-4" />
+        </button>
+        <button
+          v-if="showSubmitButton"
+          type="submit"
+          class="sh-search__submit"
+        >
+          Найти
+        </button>
+      </form>
+    </PopoverAnchor>
+
+    <PopoverContent
+      align="start"
+      :side-offset="10"
+      class="w-[min(620px,92vw)] p-0 rounded-2xl overflow-hidden border border-border shadow-2xl"
+      @open-auto-focus.prevent
+      @close-auto-focus.prevent
+    >
+      <!-- Загрузка -->
+      <div v-if="isSearching" class="p-8 flex justify-center">
+        <div class="flex items-center gap-3 text-primary">
+          <Icon name="lucide:loader-2" class="size-5 animate-spin" />
+          <span class="text-sm font-medium">Поиск…</span>
+        </div>
+      </div>
+
+      <!-- Результаты -->
+      <div
+        v-else-if="hasResults || brandSuggestions.length > 0"
+        :id="LISTBOX_ID"
+        role="listbox"
+        aria-label="Результаты поиска"
+        class="max-h-[60vh] overflow-y-auto p-4 flex flex-col gap-4"
+      >
+        <div v-if="brandSuggestions.length > 0" class="flex flex-col gap-2">
+          <h3 class="text-xs font-semibold text-muted-foreground uppercase tracking-wide px-1">
+            Бренды
+          </h3>
+          <div class="grid grid-cols-2 gap-2">
+            <NuxtLink
+              v-for="(brand, i) in brandSuggestions"
+              :id="brandOptions[i]?.id"
+              :key="brand.id"
+              :to="`/brand/${brand.slug}`"
+              role="option"
+              :aria-selected="isActive(brandOptions[i]?.id ?? '')"
+              class="flex items-center gap-3 px-3 py-2.5 bg-accent rounded-lg hover:shadow-md transition-all border border-border"
+              :class="{ 'ring-2 ring-primary': isActive(brandOptions[i]?.id ?? '') }"
+              @click="open = false"
+            >
+              <Icon name="lucide:tag" class="size-4 text-primary shrink-0" />
+              <span class="text-sm font-medium text-foreground truncate">{{ brand.name }}</span>
+            </NuxtLink>
+          </div>
+        </div>
+
+        <div v-if="hasResults" class="flex flex-col gap-2">
+          <div class="flex items-center justify-between px-1">
+            <h3 class="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              Товары · {{ searchResults.length }}
+            </h3>
+            <button
+              type="button"
+              class="text-sm text-primary hover:text-primary/80 font-medium"
+              @click="showAll"
+            >
+              Показать все
+            </button>
+          </div>
+
+          <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <NuxtLink
+              v-for="(product, i) in searchResults.slice(0, 6)"
+              :id="productOptions[i]?.id"
+              :key="product.id"
+              :to="`/catalog/products/${product.slug}`"
+              role="option"
+              :aria-selected="isActive(productOptions[i]?.id ?? '')"
+              class="group flex flex-col gap-2 p-2.5 bg-card rounded-xl hover:shadow-lg transition-all border border-border hover:border-primary/40"
+              :class="{ 'border-primary ring-2 ring-primary': isActive(productOptions[i]?.id ?? '') }"
+              @click="open = false"
+            >
+              <div class="aspect-square rounded-lg overflow-hidden bg-muted">
+                <ProgressiveImage
+                  v-if="product.product_images[0]?.image_url"
+                  :src="productImageUrl(product.product_images[0].image_url)"
+                  :alt="product.name"
+                  aspect-ratio="square"
+                  object-fit="cover"
+                  placeholder-type="lqip"
+                  :blur-data-url="product.product_images[0].blur_placeholder"
+                  :bucket-name="BUCKET_NAME_PRODUCT"
+                  :file-path="product.product_images[0].image_url"
+                  class="w-full h-full object-cover group-hover:scale-105 transition-transform"
+                  eager
+                />
+                <div v-else class="w-full h-full flex items-center justify-center">
+                  <Icon name="lucide:package" class="size-8 text-muted-foreground/60" />
+                </div>
+              </div>
+              <div class="flex-1 flex flex-col gap-1">
+                <h4 class="text-sm font-medium text-foreground line-clamp-2 leading-tight">
+                  {{ product.name }}
+                </h4>
+                <div class="flex items-center gap-1.5 mt-auto">
+                  <span
+                    class="text-sm font-bold"
+                    :class="formatPrice(product.price, product.discount_percentage).hasDiscount ? 'text-destructive' : 'text-foreground'"
+                  >
+                    {{ formatPrice(product.price, product.discount_percentage).final }} ₸
+                  </span>
+                  <span
+                    v-if="formatPrice(product.price, product.discount_percentage).hasDiscount"
+                    class="text-xs text-muted-foreground line-through"
+                  >
+                    {{ formatPrice(product.price, product.discount_percentage).original }} ₸
+                  </span>
+                </div>
+              </div>
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+
+      <!-- Ничего не найдено -->
+      <div v-else-if="hasQuery && !isSearching" class="p-8 text-center">
+        <Icon name="lucide:search-x" class="size-14 mx-auto text-muted-foreground/50 mb-3" />
+        <h3 class="text-base font-semibold text-foreground mb-1">
+          Ничего не найдено
+        </h3>
+        <p class="text-sm text-muted-foreground">
+          Попробуйте изменить запрос
+        </p>
+      </div>
+
+      <!-- История / подсказки -->
+      <div v-else class="max-h-[60vh] overflow-y-auto p-4">
+        <div v-if="suggestions.length > 0">
+          <div class="flex items-center justify-between px-1 mb-2">
+            <h3 class="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              {{ hasQuery ? 'Из истории' : 'Недавние запросы' }}
+            </h3>
+            <button
+              v-if="suggestions.some((s) => s.type === 'history')"
+              type="button"
+              class="text-xs text-primary hover:text-primary/80 font-medium"
+              @click="clearSearchHistory"
+            >
+              Очистить
+            </button>
+          </div>
+          <div :id="LISTBOX_ID" role="listbox" aria-label="Подсказки" class="flex flex-col gap-1">
+            <button
+              v-for="(item, index) in suggestions"
+              :id="suggestionOptions[index]?.id"
+              :key="index"
+              type="button"
+              role="option"
+              :aria-selected="isActive(suggestionOptions[index]?.id ?? '')"
+              class="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-accent transition-colors text-left group"
+              :class="{ 'bg-accent': isActive(suggestionOptions[index]?.id ?? '') }"
+              @click="pickSuggestion(item.text)"
+            >
+              <Icon
+                :name="item.type === 'history' ? 'lucide:history' : 'lucide:trending-up'"
+                class="size-4 shrink-0"
+                :class="item.type === 'history' ? 'text-muted-foreground' : 'text-primary'"
+              />
+              <span class="flex-1 truncate text-muted-foreground group-hover:text-foreground font-medium">
+                {{ item.text }}
+              </span>
+              <button
+                v-if="item.type === 'history'"
+                type="button"
+                class="size-6 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 hover:bg-destructive/10 transition-all"
+                aria-label="Удалить из истории"
+                @click="onRemoveHistory(item.text, $event)"
+              >
+                <Icon name="lucide:x" class="size-4 text-muted-foreground hover:text-destructive" />
+              </button>
+            </button>
+          </div>
+        </div>
+        <div v-else class="py-6 text-center text-sm text-muted-foreground">
+          Начните вводить название товара или бренда
+        </div>
+      </div>
+    </PopoverContent>
+  </Popover>
+</template>
+
+<style scoped>
+.sh-search {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 46px;
+  padding: 0 18px;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 999px;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 0.12);
+}
+
+.sh-search--dense {
+  height: 38px;
+  padding: 0 13px;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 12px;
+  box-shadow: none;
+}
+
+.sh-search__icon {
+  flex: none;
+  width: 19px;
+  height: 19px;
+  color: var(--muted-foreground);
+}
+
+.sh-search--dense .sh-search__icon {
+  width: 17px;
+  height: 17px;
+}
+
+.sh-search__input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  font: 500 15px var(--font-sans);
+  color: var(--foreground);
+}
+
+.sh-search--dense .sh-search__input {
+  font-size: 14px;
+}
+
+/* Убираем нативный крестик у type=search */
+.sh-search__input::-webkit-search-decoration,
+.sh-search__input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.sh-search__clear {
+  flex: none;
+  display: grid;
+  place-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  color: var(--muted-foreground);
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.sh-search__clear:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.sh-search__submit {
+  flex: none;
+  height: 32px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font: 600 13.5px var(--font-sans);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease;
+}
+
+/* var(--blue-600) doesn't exist (Tailwind v4 generates --color-blue-600, and
+   even that isn't guaranteed to survive tree-shaking) — --brand-hover is the
+   already-proven literal for this exact primary-button-hover case, see
+   StickySearchRow.vue / BrandsRail.vue. */
+.sh-search__submit:hover {
+  background: var(--brand-hover);
+}
+
+/* Pulls the button flush toward the pill's own rounded edge instead of
+   sitting inside the regular (symmetric) form padding — matches the
+   mockup's own form, which used a tighter right pad (6px) than left (16px)
+   specifically because the button supplies its own visual edge. Only
+   applies when the button is actually rendered; doesn't touch the
+   left/icon side or any other consumer's padding. */
+.sh-search--with-submit {
+  padding-right: 6px;
+}
+</style>

--- a/components/global/CatalogHeader.vue
+++ b/components/global/CatalogHeader.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+defineProps<{ hideMobileTrigger?: boolean, hideDesktopTrigger?: boolean }>()
+
 const sortBy = defineModel<string>('sortBy', { required: true })
+const isDrawerOpen = defineModel<boolean>('open', { default: false })
 
 const sortOptions = [
   { value: 'popularity', label: 'Популярные', icon: 'lucide:trending-up', description: 'Сначала популярные товары' },
@@ -9,7 +12,6 @@ const sortOptions = [
 ]
 
 const isPopoverOpen = ref(false)
-const isDrawerOpen = ref(false)
 
 // Проверяем, активна ли не-дефолтная сортировка
 const isActive = computed(() => sortBy.value !== 'popularity')
@@ -33,7 +35,7 @@ function selectSort(value: string) {
 
 <template>
   <!-- Десктоп: Popover -->
-  <Popover v-model:open="isPopoverOpen">
+  <Popover v-if="!hideDesktopTrigger" v-model:open="isPopoverOpen">
     <PopoverTrigger as-child>
       <Button
         :variant="isActive ? 'default' : 'outline'"
@@ -91,6 +93,7 @@ function selectSort(value: string) {
 
   <!-- Мобилка: только кнопка для открытия Drawer -->
   <Button
+    v-if="!hideMobileTrigger"
     :variant="isActive ? 'default' : 'outline'"
     class="h-11 w-11 p-0 shrink-0 transition-colors lg:hidden"
     :class="[

--- a/components/global/DynamicFilters.vue
+++ b/components/global/DynamicFilters.vue
@@ -245,494 +245,544 @@ watch(() => props.numericAttributeRanges, (newRanges) => {
     }
   })
 }, { deep: true, immediate: true })
+
+// --- 4. UI-МЕЛОЧИ (тонкий скроллбар, появляется только во время скролла) ---
+const isScrolling = ref(false)
+let scrollTimeout: ReturnType<typeof setTimeout> | undefined
+
+function onAsideScroll() {
+  isScrolling.value = true
+  clearTimeout(scrollTimeout)
+  scrollTimeout = setTimeout(() => {
+    isScrolling.value = false
+  }, 700)
+}
+
+onUnmounted(() => {
+  clearTimeout(scrollTimeout)
+})
 </script>
 
 <template>
-  <div class="bg-white border rounded-xl p-4 flex flex-col sticky top-4 h-[calc(100vh-1rem)]">
-    <!-- Заголовок -->
-    <div class="flex items-center justify-between pb-3 border-b shrink-0">
-      <div class="flex items-center gap-2">
-        <Icon name="lucide:sliders-horizontal" class="w-5 h-5 text-muted-foreground" />
-        <h3 class="font-bold text-lg">
-          Фильтры
-        </h3>
-      </div>
-      <Badge v-if="activeFiltersCount > 0" variant="secondary" class="bg-primary/10 text-primary">
-        {{ activeFiltersCount }}
-      </Badge>
+  <div class="df-aside thin-scroll" :class="{ scrolling: isScrolling }" @scroll="onAsideScroll">
+    <div class="df-header-row">
+      <span class="df-title">
+        <Icon name="lucide:sliders-horizontal" class="df-title-icon" />
+        Фильтры
+      </span>
+      <button v-if="activeFiltersCount > 0" type="button" class="df-reset" @click="resetFilters">
+        Сбросить
+      </button>
     </div>
 
-    <!-- Контент с прокруткой -->
-    <div class="space-y-3 flex-1 overflow-y-auto pr-2 scrollbar-thin mt-4">
-      <!-- 1. ФИЛЬТР ПО ПОДКАТЕГОРИЯМ -->
-      <div v-if="subcategories.length > 0" class="space-y-2">
-        <div class="flex items-center gap-2 mb-2">
-          <Icon name="lucide:layers" class="w-4 h-4 text-muted-foreground" />
-          <h4 class="font-semibold text-sm">
-            Подкатегории
-          </h4>
-        </div>
-        <button
-          v-for="cat in subcategories"
-          :key="cat.id"
-          type="button"
-          class="w-full flex items-center gap-3 p-3 rounded-lg transition-all duration-200 text-sm"
-          :class="[
-            props.modelValue.subCategoryIds.includes(cat.id)
-              ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md shadow-blue-500/20'
-              : 'bg-secondary/60 hover:bg-secondary hover:shadow-sm active:scale-[0.98]',
-          ]"
-          @click="updateSubCategory(!props.modelValue.subCategoryIds.includes(cat.id), cat.id)"
-        >
-          <div
-            class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-            :class="props.modelValue.subCategoryIds.includes(cat.id) ? 'bg-white/20' : 'bg-background/50'"
-          >
-            <Icon
-              :name="props.modelValue.subCategoryIds.includes(cat.id) ? 'lucide:check' : 'lucide:folder'"
-              class="w-4 h-4"
-            />
-          </div>
-          <div class="flex-1 text-left font-medium">
-            {{ cat.name }}
-          </div>
-        </button>
+    <!-- 1. ФИЛЬТР ПО ПОДКАТЕГОРИЯМ -->
+    <div v-if="subcategories.length > 0" class="df-card df-card--tight">
+      <button
+        v-for="cat in subcategories"
+        :key="cat.id"
+        type="button"
+        class="df-row"
+        :class="{ 'df-row--active': props.modelValue.subCategoryIds.includes(cat.id) }"
+        @click="updateSubCategory(!props.modelValue.subCategoryIds.includes(cat.id), cat.id)"
+      >
+        <span class="df-row-label">{{ cat.name }}</span>
+      </button>
+    </div>
+
+    <!-- 2. БРЕНДЫ -->
+    <div v-if="availableBrands.length > 0" class="df-card">
+      <div class="df-card-title">
+        Бренды
+      </div>
+      <button
+        v-for="brand in availableBrands"
+        :key="brand.id"
+        type="button"
+        class="df-row df-row--boxed"
+        :class="{ 'df-row--active': modelValue.brandIds?.includes(brand.id) }"
+        @click="updateDirectFilter(!modelValue.brandIds?.includes(brand.id), 'brandIds', brand.id)"
+      >
+        <span class="df-box" :class="{ 'df-box--active': modelValue.brandIds?.includes(brand.id) }">
+          <Icon v-if="modelValue.brandIds?.includes(brand.id)" name="lucide:check" class="df-box-icon" />
+        </span>
+        <span class="df-row-label">{{ brand.name }}</span>
+        <span v-if="brand.products_count" class="df-row-count">{{ brand.products_count }}</span>
+      </button>
+    </div>
+
+    <!-- 2.5. ЛИНЕЙКИ ПРОДУКТОВ -->
+    <div v-if="availableProductLines.length > 0" class="df-card">
+      <div class="df-card-title">
+        Линейки
+      </div>
+      <button
+        v-for="line in availableProductLines"
+        :key="line.id"
+        type="button"
+        class="df-row df-row--boxed"
+        :class="{ 'df-row--active': modelValue.productLineIds?.includes(line.id) }"
+        @click="updateDirectFilter(!modelValue.productLineIds?.includes(line.id), 'productLineIds', line.id)"
+      >
+        <span class="df-box" :class="{ 'df-box--active': modelValue.productLineIds?.includes(line.id) }">
+          <Icon v-if="modelValue.productLineIds?.includes(line.id)" name="lucide:check" class="df-box-icon" />
+        </span>
+        <span class="df-row-label">{{ line.name }}</span>
+      </button>
+    </div>
+
+    <!-- 3. МАТЕРИАЛЫ -->
+    <div v-if="availableMaterials.length > 0" class="df-card">
+      <div class="df-card-title">
+        Материал
+      </div>
+      <button
+        v-for="material in availableMaterials"
+        :key="material.id"
+        type="button"
+        class="df-row df-row--boxed"
+        :class="{ 'df-row--active': modelValue.materialIds?.includes(String(material.id)) }"
+        @click="updateDirectFilter(!modelValue.materialIds?.includes(String(material.id)), 'materialIds', material.id)"
+      >
+        <span class="df-box" :class="{ 'df-box--active': modelValue.materialIds?.includes(String(material.id)) }">
+          <Icon v-if="modelValue.materialIds?.includes(String(material.id))" name="lucide:check" class="df-box-icon" />
+        </span>
+        <span class="df-row-label">{{ material.name }}</span>
+      </button>
+    </div>
+
+    <!-- 4. СТРАНЫ -->
+    <div v-if="availableCountries.length > 0" class="df-card">
+      <div class="df-card-title">
+        Страна происхождения
+      </div>
+      <button
+        v-for="country in availableCountries"
+        :key="country.id"
+        type="button"
+        class="df-row df-row--boxed"
+        :class="{ 'df-row--active': modelValue.countryIds?.includes(String(country.id)) }"
+        @click="updateDirectFilter(!modelValue.countryIds?.includes(String(country.id)), 'countryIds', country.id)"
+      >
+        <span class="df-box" :class="{ 'df-box--active': modelValue.countryIds?.includes(String(country.id)) }">
+          <Icon v-if="modelValue.countryIds?.includes(String(country.id))" name="lucide:check" class="df-box-icon" />
+        </span>
+        <span class="df-row-label">{{ country.name }}</span>
+      </button>
+    </div>
+
+    <!-- 5. ДИНАМИЧЕСКИЕ АТРИБУТЫ (без number_range - он заменён на слайдер piece_count) -->
+    <div
+      v-for="filter in displayableFilters"
+      :key="filter.id"
+      class="df-card"
+    >
+      <div class="df-card-title">
+        {{ filter.name }}
       </div>
 
-      <!-- 2. БРЕНДЫ -->
-      <div v-if="availableBrands.length > 0" class="space-y-2 pt-3 border-t">
-        <div class="flex items-center gap-2 mb-2">
-          <Icon name="lucide:tag" class="w-4 h-4 text-muted-foreground" />
-          <h4 class="font-semibold text-sm">
-            Бренды
-          </h4>
-        </div>
+      <!-- Для типа 'select' -->
+      <template v-if="filter.display_type === 'select'">
         <button
-          v-for="brand in availableBrands"
-          :key="brand.id"
+          v-for="option in filter.attribute_options"
+          :key="option.id"
           type="button"
-          class="w-full flex items-center gap-3 p-3 rounded-lg transition-all duration-200 text-sm"
-          :class="[
-            modelValue.brandIds?.includes(brand.id)
-              ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white shadow-md shadow-purple-500/20'
-              : 'bg-secondary/60 hover:bg-secondary hover:shadow-sm active:scale-[0.98]',
-          ]"
-          @click="updateDirectFilter(!modelValue.brandIds?.includes(brand.id), 'brandIds', brand.id)"
+          class="df-row df-row--boxed"
+          :class="{ 'df-row--active': modelValue.attributes[filter.slug]?.includes(option.id) }"
+          @click="updateAttribute(!modelValue.attributes[filter.slug]?.includes(option.id), filter.slug, option.id)"
         >
-          <div
-            class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-            :class="modelValue.brandIds?.includes(brand.id) ? 'bg-white/20' : 'bg-background/50'"
-          >
-            <Icon
-              :name="modelValue.brandIds?.includes(brand.id) ? 'lucide:check' : 'lucide:award'"
-              class="w-4 h-4"
-            />
-          </div>
-          <div class="flex-1 text-left font-medium">
-            {{ brand.name }}
-          </div>
+          <span class="df-box" :class="{ 'df-box--active': modelValue.attributes[filter.slug]?.includes(option.id) }">
+            <Icon v-if="modelValue.attributes[filter.slug]?.includes(option.id)" name="lucide:check" class="df-box-icon" />
+          </span>
+          <span class="df-row-label">{{ option.value }}</span>
         </button>
-      </div>
+      </template>
 
-      <!-- 2.5. ЛИНЕЙКИ ПРОДУКТОВ -->
-      <div v-if="availableProductLines.length > 0" class="space-y-2 pt-3 border-t">
-        <div class="flex items-center gap-2 mb-2">
-          <Icon name="lucide:sparkles" class="w-4 h-4 text-muted-foreground" />
-          <h4 class="font-semibold text-sm">
-            Линейки
-          </h4>
+      <!-- Для типа 'color' -->
+      <template v-if="filter.display_type === 'color'">
+        <div class="df-color-grid">
+          <button
+            v-for="option in filter.attribute_options"
+            :key="option.id"
+            type="button"
+            :title="option.value"
+            class="df-color-item"
+            :class="{ 'df-color-item--active': modelValue.attributes[filter.slug]?.includes(option.id) }"
+            @click="() => {
+              const isCurrentlyChecked = modelValue.attributes[filter.slug]?.includes(option.id);
+              updateAttribute(!isCurrentlyChecked, filter.slug, option.id);
+            }"
+          >
+            <span
+              class="df-color-swatch"
+              :style="{ backgroundColor: ((option.meta as unknown) as ColorOptionMeta)?.hex }"
+            />
+            <span class="df-color-label">{{ option.value }}</span>
+          </button>
         </div>
-        <button
-          v-for="line in availableProductLines"
-          :key="line.id"
-          type="button"
-          class="w-full flex items-center gap-3 p-3 rounded-lg transition-all duration-200 text-sm"
-          :class="[
-            modelValue.productLineIds?.includes(line.id)
-              ? 'bg-gradient-to-r from-pink-500 to-pink-600 text-white shadow-md shadow-pink-500/20'
-              : 'bg-secondary/60 hover:bg-secondary hover:shadow-sm active:scale-[0.98]',
-          ]"
-          @click="updateDirectFilter(!modelValue.productLineIds?.includes(line.id), 'productLineIds', line.id)"
-        >
-          <div
-            class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-            :class="modelValue.productLineIds?.includes(line.id) ? 'bg-white/20' : 'bg-background/50'"
-          >
-            <Icon
-              :name="modelValue.productLineIds?.includes(line.id) ? 'lucide:check' : 'lucide:sparkles'"
-              class="w-4 h-4"
-            />
-          </div>
-          <div class="flex-1 text-left font-medium">
-            {{ line.name }}
-          </div>
-        </button>
-      </div>
+      </template>
+    </div>
 
-      <!-- 3. МАТЕРИАЛЫ -->
-      <div v-if="availableMaterials.length > 0" class="space-y-2 pt-3 border-t">
-        <div class="flex items-center gap-2 mb-2">
-          <Icon name="lucide:layers-2" class="w-4 h-4 text-muted-foreground" />
-          <h4 class="font-semibold text-sm">
-            Материал
-          </h4>
-        </div>
-        <button
-          v-for="material in availableMaterials"
-          :key="material.id"
-          type="button"
-          class="w-full flex items-center gap-3 p-3 rounded-lg transition-all duration-200 text-sm"
-          :class="[
-            modelValue.materialIds?.includes(String(material.id))
-              ? 'bg-gradient-to-r from-green-500 to-green-600 text-white shadow-md shadow-green-500/20'
-              : 'bg-secondary/60 hover:bg-secondary hover:shadow-sm active:scale-[0.98]',
-          ]"
-          @click="updateDirectFilter(!modelValue.materialIds?.includes(String(material.id)), 'materialIds', material.id)"
-        >
-          <div
-            class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-            :class="modelValue.materialIds?.includes(String(material.id)) ? 'bg-white/20' : 'bg-background/50'"
-          >
-            <Icon
-              :name="modelValue.materialIds?.includes(String(material.id)) ? 'lucide:check' : 'lucide:box'"
-              class="w-4 h-4"
-            />
-          </div>
-          <div class="flex-1 text-left font-medium">
-            {{ material.name }}
-          </div>
-        </button>
-      </div>
-
-      <!-- 4. СТРАНЫ -->
-      <div v-if="availableCountries.length > 0" class="space-y-2 pt-3 border-t">
-        <div class="flex items-center gap-2 mb-2">
-          <Icon name="lucide:globe" class="w-4 h-4 text-muted-foreground" />
-          <h4 class="font-semibold text-sm">
-            Страна происхождения
-          </h4>
-        </div>
-        <button
-          v-for="country in availableCountries"
-          :key="country.id"
-          type="button"
-          class="w-full flex items-center gap-3 p-3 rounded-lg transition-all duration-200 text-sm"
-          :class="[
-            modelValue.countryIds?.includes(String(country.id))
-              ? 'bg-gradient-to-r from-orange-500 to-orange-600 text-white shadow-md shadow-orange-500/20'
-              : 'bg-secondary/60 hover:bg-secondary hover:shadow-sm active:scale-[0.98]',
-          ]"
-          @click="updateDirectFilter(!modelValue.countryIds?.includes(String(country.id)), 'countryIds', country.id)"
-        >
-          <div
-            class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-            :class="modelValue.countryIds?.includes(String(country.id)) ? 'bg-white/20' : 'bg-background/50'"
-          >
-            <Icon
-              :name="modelValue.countryIds?.includes(String(country.id)) ? 'lucide:check' : 'lucide:map-pin'"
-              class="w-4 h-4"
-            />
-          </div>
-          <div class="flex-1 text-left font-medium">
-            {{ country.name }}
-          </div>
-        </button>
-      </div>
-
-      <!-- 5. ДИНАМИЧЕСКИЕ АТРИБУТЫ (без number_range - он заменён на слайдер piece_count) -->
+    <!-- 5.5. ЧИСЛОВЫЕ АТРИБУТЫ (слайдеры) -->
+    <ClientOnly v-for="numericFilter in numericFilters" :key="`numeric-${numericFilter.id}`">
       <div
-        v-for="filter in displayableFilters"
-        :key="filter.id"
-        class="space-y-2 pt-3 border-t"
+        v-if="numericAttributeRanges[numericFilter.id] && localNumericAttributes[numericFilter.id]"
+        class="df-card"
       >
-        <div class="flex items-center gap-2 mb-2">
-          <Icon name="lucide:settings-2" class="w-4 h-4 text-muted-foreground" />
-          <h4 class="font-semibold text-sm">
-            {{ filter.name }}
-          </h4>
+        <div class="df-card-title">
+          {{ numericFilter.name }}
         </div>
 
-        <!-- Для типа 'select' -->
-        <template v-if="filter.display_type === 'select'">
-          <div class="space-y-2">
-            <button
-              v-for="option in filter.attribute_options"
-              :key="option.id"
-              type="button"
-              class="w-full flex items-center gap-3 p-3 rounded-lg transition-all duration-200 text-sm"
-              :class="[
-                modelValue.attributes[filter.slug]?.includes(option.id)
-                  ? 'bg-gradient-to-r from-pink-500 to-pink-600 text-white shadow-md shadow-pink-500/20'
-                  : 'bg-secondary/60 hover:bg-secondary hover:shadow-sm active:scale-[0.98]',
-              ]"
-              @click="updateAttribute(!modelValue.attributes[filter.slug]?.includes(option.id), filter.slug, option.id)"
-            >
-              <div
-                class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-                :class="modelValue.attributes[filter.slug]?.includes(option.id) ? 'bg-white/20' : 'bg-background/50'"
-              >
-                <Icon
-                  :name="modelValue.attributes[filter.slug]?.includes(option.id) ? 'lucide:check' : 'lucide:circle'"
-                  class="w-4 h-4"
-                />
-              </div>
-              <div class="flex-1 text-left font-medium">
-                {{ option.value }}
-              </div>
-            </button>
+        <template v-if="isLoading">
+          <div class="space-y-2 pb-3">
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-1/2" />
           </div>
         </template>
-
-        <!-- Для типа 'color' -->
-        <template v-if="filter.display_type === 'color'">
-          <div class="grid grid-cols-3 gap-2 pt-2">
-            <button
-              v-for="option in filter.attribute_options"
-              :key="option.id"
-              type="button"
-              :title="option.value"
-              class="relative flex flex-col items-center gap-1.5 p-2 rounded-lg transition-all duration-200"
-              :class="[
-                modelValue.attributes[filter.slug]?.includes(option.id)
-                  ? 'bg-primary/10 ring-2 ring-primary'
-                  : 'bg-secondary/60 hover:bg-secondary active:scale-95',
-              ]"
-              @click="() => {
-                const isCurrentlyChecked = modelValue.attributes[filter.slug]?.includes(option.id);
-                updateAttribute(!isCurrentlyChecked, filter.slug, option.id);
-              }"
-            >
-              <div
-                :style="{ backgroundColor: ((option.meta as unknown) as ColorOptionMeta)?.hex }"
-                class="h-10 w-10 rounded-md border-2 transition-transform"
-                :class="{
-                  'border-primary scale-110': modelValue.attributes[filter.slug]?.includes(option.id),
-                  'border-border': !modelValue.attributes[filter.slug]?.includes(option.id),
-                }"
-              />
-              <span class="text-[10px] font-medium text-center line-clamp-1">
-                {{ option.value }}
-              </span>
-              <Icon
-                v-if="modelValue.attributes[filter.slug]?.includes(option.id)"
-                name="lucide:check-circle"
-                class="absolute top-0.5 right-0.5 w-4 h-4 text-primary"
-              />
-            </button>
+        <template v-else>
+          <div class="df-slider-wrap">
+            <Slider
+              v-model="localNumericAttributes[numericFilter.id]"
+              :min="numericAttributeRanges[numericFilter.id].min"
+              :max="numericAttributeRanges[numericFilter.id].max"
+              :step="1"
+              @value-commit="(val: number[]) => commitNumericAttributeToFilters(numericFilter.id, val)"
+            />
+          </div>
+          <div class="df-slider-values">
+            <span>{{ localNumericAttributes[numericFilter.id][0] }} {{ (numericFilter as any).unit || '' }}</span>
+            <span>{{ localNumericAttributes[numericFilter.id][1] }} {{ (numericFilter as any).unit || '' }}</span>
           </div>
         </template>
       </div>
 
-      <!-- 5.5. ЧИСЛОВЫЕ АТРИБУТЫ (слайдеры) -->
-      <ClientOnly v-for="numericFilter in numericFilters" :key="`numeric-${numericFilter.id}`">
-        <div
-          v-if="numericAttributeRanges[numericFilter.id] && localNumericAttributes[numericFilter.id]"
-          class="space-y-3 pt-3 border-t"
-        >
-          <div class="flex items-center gap-2">
-            <Icon name="lucide:ruler" class="w-4 h-4 text-muted-foreground" />
-            <h4 class="font-semibold text-sm">
-              {{ numericFilter.name }}
-            </h4>
+      <!-- Fallback для SSR -->
+      <template #fallback>
+        <div class="df-card">
+          <div class="df-card-title">
+            {{ numericFilter.name }}
           </div>
+          <div class="space-y-2 pb-3">
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-1/2" />
+          </div>
+        </div>
+      </template>
+    </ClientOnly>
 
-          <template v-if="isLoading">
-            <div class="space-y-3 pt-2">
-              <Skeleton class="h-3 w-full" />
-              <Skeleton class="h-3 w-1/2" />
-            </div>
-          </template>
-          <template v-else>
-            <div class="px-1 pt-2">
-              <Slider
-                v-model="localNumericAttributes[numericFilter.id]"
-                :min="numericAttributeRanges[numericFilter.id].min"
-                :max="numericAttributeRanges[numericFilter.id].max"
-                :step="1"
-                @value-commit="(val: number[]) => commitNumericAttributeToFilters(numericFilter.id, val)"
-              />
-            </div>
-            <div class="flex justify-between items-center gap-2">
-              <div class="flex-1 p-2 rounded-lg bg-secondary/60 text-center">
-                <div class="text-[10px] text-muted-foreground mb-0.5">
-                  От
-                </div>
-                <div class="font-semibold text-xs">
-                  {{ localNumericAttributes[numericFilter.id][0] }} {{ (numericFilter as any).unit || '' }}
-                </div>
-              </div>
-              <Icon name="lucide:minus" class="w-3 h-3 text-muted-foreground" />
-              <div class="flex-1 p-2 rounded-lg bg-secondary/60 text-center">
-                <div class="text-[10px] text-muted-foreground mb-0.5">
-                  До
-                </div>
-                <div class="font-semibold text-xs">
-                  {{ localNumericAttributes[numericFilter.id][1] }} {{ (numericFilter as any).unit || '' }}
-                </div>
-              </div>
-            </div>
-          </template>
+    <!-- 6. ФИЛЬТР ПО ЦЕНЕ -->
+    <ClientOnly>
+      <div class="df-card">
+        <div class="df-card-title">
+          Цена, ₸
         </div>
 
-        <!-- Fallback для SSR -->
-        <template #fallback>
-          <div class="space-y-3 pt-3 border-t">
-            <div class="flex items-center gap-2">
-              <Icon name="lucide:ruler" class="w-4 h-4 text-muted-foreground" />
-              <h4 class="font-semibold text-sm">
-                {{ numericFilter.name }}
-              </h4>
-            </div>
-            <div class="space-y-3 pt-2">
-              <Skeleton class="h-3 w-full" />
-              <Skeleton class="h-3 w-1/2" />
-            </div>
+        <template v-if="isLoading">
+          <div class="space-y-2 pb-3">
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-1/2" />
           </div>
         </template>
-      </ClientOnly>
-
-      <!-- 6. ФИЛЬТР ПО ЦЕНЕ -->
-      <ClientOnly>
-        <div class="space-y-3 pt-3 border-t">
-          <div class="flex items-center gap-2">
-            <Icon name="lucide:wallet" class="w-4 h-4 text-muted-foreground" />
-            <h4 class="font-semibold text-sm">
-              Цена
-            </h4>
+        <template v-else>
+          <div class="df-slider-wrap">
+            <Slider
+              v-model="localPrice"
+              :min="priceRange.min"
+              :max="priceRange.max"
+              :step="100"
+              @value-commit="commitPriceToFilters"
+            />
           </div>
+          <div class="df-slider-values">
+            <span>{{ new Intl.NumberFormat('ru-RU').format(Math.round(localPrice[0])) }} ₸</span>
+            <span>{{ new Intl.NumberFormat('ru-RU').format(Math.round(localPrice[1])) }} ₸</span>
+          </div>
+        </template>
+      </div>
 
-          <template v-if="isLoading">
-            <div class="space-y-3 pt-2">
-              <Skeleton class="h-3 w-full" />
-              <Skeleton class="h-3 w-1/2" />
-            </div>
-          </template>
-          <template v-else>
-            <div class="px-1 pt-2">
-              <Slider
-                v-model="localPrice"
-                :min="priceRange.min"
-                :max="priceRange.max"
-                :step="100"
-                @value-commit="commitPriceToFilters"
-              />
-            </div>
-            <div class="flex justify-between items-center gap-2">
-              <div class="flex-1 p-2 rounded-lg bg-secondary/60 text-center">
-                <div class="text-[10px] text-muted-foreground mb-0.5">
-                  От
-                </div>
-                <div class="font-semibold text-xs">
-                  {{ new Intl.NumberFormat('ru-RU').format(Math.round(localPrice[0])) }} ₸
-                </div>
-              </div>
-              <Icon name="lucide:minus" class="w-3 h-3 text-muted-foreground" />
-              <div class="flex-1 p-2 rounded-lg bg-secondary/60 text-center">
-                <div class="text-[10px] text-muted-foreground mb-0.5">
-                  До
-                </div>
-                <div class="font-semibold text-xs">
-                  {{ new Intl.NumberFormat('ru-RU').format(Math.round(localPrice[1])) }} ₸
-                </div>
-              </div>
-            </div>
-          </template>
+      <!-- Fallback для SSR -->
+      <template #fallback>
+        <div class="df-card">
+          <div class="df-card-title">
+            Цена, ₸
+          </div>
+          <div class="space-y-2 pb-3">
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-1/2" />
+          </div>
+        </div>
+      </template>
+    </ClientOnly>
+
+    <!-- 7. ФИЛЬТР ПО КОЛИЧЕСТВУ ДЕТАЛЕЙ (для конструкторов) -->
+    <ClientOnly v-if="pieceCountRange && localPieceCount">
+      <div class="df-card">
+        <div class="df-card-title">
+          Количество деталей
         </div>
 
-        <!-- Fallback для SSR -->
-        <template #fallback>
-          <div class="space-y-3 pt-3 border-t">
-            <div class="flex items-center gap-2">
-              <Icon name="lucide:wallet" class="w-4 h-4 text-muted-foreground" />
-              <h4 class="font-semibold text-sm">
-                Цена
-              </h4>
-            </div>
-            <div class="space-y-3 pt-2">
-              <Skeleton class="h-3 w-full" />
-              <Skeleton class="h-3 w-1/2" />
-            </div>
+        <template v-if="isLoading">
+          <div class="space-y-2 pb-3">
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-1/2" />
           </div>
         </template>
-      </ClientOnly>
-
-      <!-- 7. ФИЛЬТР ПО КОЛИЧЕСТВУ ДЕТАЛЕЙ (для конструкторов) -->
-      <ClientOnly v-if="pieceCountRange && localPieceCount">
-        <div class="space-y-3 pt-3 border-t">
-          <div class="flex items-center gap-2">
-            <Icon name="lucide:puzzle" class="w-4 h-4 text-muted-foreground" />
-            <h4 class="font-semibold text-sm">
-              Количество деталей
-            </h4>
+        <template v-else>
+          <div class="df-slider-wrap">
+            <Slider
+              v-model="localPieceCount"
+              :min="pieceCountRange.min"
+              :max="pieceCountRange.max"
+              :step="10"
+              @value-commit="commitPieceCountToFilters"
+            />
           </div>
+          <div class="df-slider-values">
+            <span>{{ localPieceCount[0] }} шт</span>
+            <span>{{ localPieceCount[1] }} шт</span>
+          </div>
+        </template>
+      </div>
 
-          <template v-if="isLoading">
-            <div class="space-y-3 pt-2">
-              <Skeleton class="h-3 w-full" />
-              <Skeleton class="h-3 w-1/2" />
-            </div>
-          </template>
-          <template v-else>
-            <div class="px-1 pt-2">
-              <Slider
-                v-model="localPieceCount"
-                :min="pieceCountRange.min"
-                :max="pieceCountRange.max"
-                :step="10"
-                @value-commit="commitPieceCountToFilters"
-              />
-            </div>
-            <div class="flex justify-between items-center gap-2">
-              <div class="flex-1 p-2 rounded-lg bg-secondary/60 text-center">
-                <div class="text-[10px] text-muted-foreground mb-0.5">
-                  От
-                </div>
-                <div class="font-semibold text-xs">
-                  {{ localPieceCount[0] }} шт
-                </div>
-              </div>
-              <Icon name="lucide:minus" class="w-3 h-3 text-muted-foreground" />
-              <div class="flex-1 p-2 rounded-lg bg-secondary/60 text-center">
-                <div class="text-[10px] text-muted-foreground mb-0.5">
-                  До
-                </div>
-                <div class="font-semibold text-xs">
-                  {{ localPieceCount[1] }} шт
-                </div>
-              </div>
-            </div>
-          </template>
+      <!-- Fallback для SSR -->
+      <template #fallback>
+        <div class="df-card">
+          <div class="df-card-title">
+            Количество деталей
+          </div>
+          <div class="space-y-2 pb-3">
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-1/2" />
+          </div>
         </div>
-
-        <!-- Fallback для SSR -->
-        <template #fallback>
-          <div class="space-y-3 pt-3 border-t">
-            <div class="flex items-center gap-2">
-              <Icon name="lucide:puzzle" class="w-4 h-4 text-muted-foreground" />
-              <h4 class="font-semibold text-sm">
-                Количество деталей
-              </h4>
-            </div>
-            <div class="space-y-3 pt-2">
-              <Skeleton class="h-3 w-full" />
-              <Skeleton class="h-3 w-1/2" />
-            </div>
-          </div>
-        </template>
-      </ClientOnly>
-    </div>
-
-    <!-- Кнопка сброса -->
-    <div v-if="activeFiltersCount > 0" class="pt-3 border-t shrink-0">
-      <Button
-        variant="outline"
-        size="sm"
-        class="w-full"
-        @click="resetFilters"
-      >
-        <Icon name="lucide:x" class="w-3 h-3 mr-2" />
-        Сбросить фильтры
-      </Button>
-    </div>
+      </template>
+    </ClientOnly>
   </div>
 </template>
+
+<style scoped>
+.df-aside {
+  /* Must clear CategoryScrollBar (fixed, top:0/z:90, ~59px tall) once it
+     docks on scroll — SiteHeader itself is non-sticky on this page, so it's
+     not a factor. Otherwise the "Фильтры" title and first row stick
+     underneath it, hidden and unclickable. */
+  position: sticky;
+  top: 70px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: calc(100vh - 70px - 1rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 6px;
+  padding-bottom: 8px;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.df-aside::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+
+.df-aside::-webkit-scrollbar-track {
+  background: transparent;
+  margin: 10px 0;
+}
+
+.df-aside::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 99px;
+}
+
+.df-aside.scrolling {
+  scrollbar-color: rgba(100, 116, 139, 0.4) transparent;
+}
+
+.df-aside.scrolling::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.35);
+}
+
+.df-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 6px;
+  flex: none;
+}
+
+.df-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font: 800 17px var(--font-sans);
+  color: var(--foreground);
+}
+
+.df-title-icon {
+  width: 17px;
+  height: 17px;
+  color: var(--primary);
+}
+
+.df-reset {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: 600 13px var(--font-sans);
+  color: var(--primary);
+  padding: 0;
+}
+
+.df-reset:hover {
+  color: var(--blue-700);
+}
+
+.df-card {
+  flex: none;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 16px 16px 8px;
+}
+
+.df-card--tight {
+  padding: 8px;
+}
+
+.df-card-title {
+  font: 700 15px var(--font-sans);
+  color: var(--foreground);
+  margin-bottom: 12px;
+}
+
+.df-card--tight .df-card-title {
+  margin: 4px 0 6px 4px;
+}
+
+.df-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 44px;
+  padding: 0 10px;
+  border: none;
+  background: transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  font: 600 14px var(--font-sans);
+  color: var(--foreground);
+  margin-bottom: 8px;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.df-row:last-child {
+  margin-bottom: 0;
+}
+
+.df-row--boxed {
+  margin-bottom: 4px;
+  padding: 0 4px;
+}
+
+.df-row--active {
+  background: rgba(43, 127, 255, 0.12);
+  color: var(--primary);
+}
+
+.df-row-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.df-row-count {
+  font: 500 12px var(--font-sans);
+  color: var(--muted-foreground);
+}
+
+.df-box {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 1.5px solid var(--border);
+  background: #fff;
+  display: grid;
+  place-content: center;
+  transition: all 0.15s ease;
+}
+
+.df-box--active {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.df-box-icon {
+  width: 13px;
+  height: 13px;
+  color: #fff;
+}
+
+.df-slider-wrap {
+  padding: 6px 4px 12px;
+}
+
+.df-slider-values {
+  display: flex;
+  justify-content: space-between;
+  font: 600 13px var(--font-sans);
+  color: var(--muted-foreground);
+  padding-bottom: 16px;
+}
+
+.df-color-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  padding-bottom: 12px;
+}
+
+.df-color-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.df-color-item--active {
+  background: rgba(43, 127, 255, 0.1);
+  box-shadow: 0 0 0 2px var(--primary) inset;
+}
+
+.df-color-swatch {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 2px solid var(--border);
+}
+
+.df-color-item--active .df-color-swatch {
+  border-color: var(--primary);
+}
+
+.df-color-label {
+  font: 500 11px var(--font-sans);
+  color: var(--foreground);
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+</style>

--- a/components/global/MobileBottomNav.vue
+++ b/components/global/MobileBottomNav.vue
@@ -3,199 +3,227 @@ import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/core/useAuthStore'
 import { useModalStore } from '@/stores/modal/useModalStore'
 import { useCartStore } from '@/stores/publicStore/cartStore'
-
-const route = useRoute()
-const cartStore = useCartStore()
-const authStore = useAuthStore()
-const modalStore = useModalStore()
-
-const { isLoggedIn } = storeToRefs(authStore)
-
-// Scroll-aware visibility
-const isVisible = ref(true)
-let lastScrollY = 0
-
-function handleScroll() {
-  const currentScrollY = window.scrollY
-  if (currentScrollY < 60) {
-    isVisible.value = true
-  }
-  else if (currentScrollY > lastScrollY) {
-    isVisible.value = false
-  }
-  else {
-    isVisible.value = true
-  }
-  lastScrollY = currentScrollY
-}
-
-onMounted(() => window.addEventListener('scroll', handleScroll, { passive: true }))
-onUnmounted(() => window.removeEventListener('scroll', handleScroll))
+import { useWishlistStore } from '@/stores/publicStore/wishlistStore'
 
 interface NavItem {
   path: string
   icon: string
+  label: string
+  badge?: 'cart' | 'wish'
+  requiresAuth?: boolean
 }
 
-// Корзина отдельно — только основная навигация
-const navItems: NavItem[] = [
-  { path: '/', icon: 'streamline-plump:home-1' },
-  { path: '/catalog', icon: 'streamline-plump:layout-window-4' },
-  { path: '/profile', icon: 'streamline-plump:user-single-neutral-male' },
+const NAV_ITEMS: NavItem[] = [
+  { path: '/', icon: 'gravity-ui:house', label: 'Главная' },
+  { path: '/catalog', icon: 'lucide:layout-grid', label: 'Каталог' },
+  { path: '/profile/wishlist', icon: 'gravity-ui:heart', label: 'Избранное', badge: 'wish', requiresAuth: true },
+  { path: '/profile', icon: 'gravity-ui:person', label: 'Профиль', requiresAuth: true },
+  { path: '/cart', icon: 'gravity-ui:shopping-bag', label: 'Корзина', badge: 'cart' },
 ]
 
-function isActive(path: string) {
-  if (path === '/')
-    return route.path === '/'
+const route = useRoute()
+const cartStore = useCartStore()
+const wishlistStore = useWishlistStore()
+const authStore = useAuthStore()
+const modalStore = useModalStore()
+
+const { isLoggedIn } = storeToRefs(authStore)
+const { totalItems: cartCount } = storeToRefs(cartStore)
+const wishCount = computed(() => wishlistStore.wishlistProductIds.length)
+
+function isActivePath(path: string) {
+  // '/profile' must match exactly — otherwise it also lights up on '/profile/wishlist'
+  if (path === '/' || path === '/profile')
+    return route.path === path
   return route.path.startsWith(path)
 }
 
-const isCartActive = computed(() => route.path.startsWith('/cart'))
+const activeIndex = computed(() => NAV_ITEMS.findIndex(item => isActivePath(item.path)))
 
-// Pill скользит только по 3 пунктам (0%, 33.33%, 66.66%)
-const activeIndex = computed(() => navItems.findIndex(item => isActive(item.path)))
+const displayItems = computed(() => NAV_ITEMS.map((item, index) => {
+  const count = item.badge === 'cart' ? cartCount.value : item.badge === 'wish' ? wishCount.value : 0
+  return {
+    ...item,
+    isActive: index === activeIndex.value,
+    badgeText: count > 99 ? '99+' : String(count),
+    showBadge: !!item.badge && count > 0,
+  }
+}))
 
-const cartItemsCount = computed(() =>
-  cartStore.items.reduce((total, item) => total + item.quantity, 0),
-)
+const lensStyle = computed(() => ({
+  transform: `translateY(-50%) translateX(${Math.max(activeIndex.value, 0) * 100}%)`,
+}))
 
-function handleProfileClick(event: Event) {
-  if (!isLoggedIn.value) {
+// NuxtLink's own navigation handler runs before a sibling `@click` listener,
+// so a plain `event.preventDefault()` there is too late to stop it. Using the
+// `custom` slot hands us the `navigate` trigger directly, so the gate always
+// runs first.
+function handleItemClick(event: MouseEvent, item: NavItem, navigate: (e?: MouseEvent) => void) {
+  if (item.requiresAuth && !isLoggedIn.value) {
     event.preventDefault()
     modalStore.openLoginModal()
+    return
+  }
+  navigate(event)
+}
+
+// Scroll-aware visibility: hide once scrolled past 280px while moving down,
+// reveal again on any upward scroll or once back near the top.
+const isHidden = ref(false)
+let lastScrollY = 0
+let ticking = false
+
+function applyScroll() {
+  ticking = false
+  const y = window.scrollY
+  const dy = y - lastScrollY
+  if (dy > 6 && y > 280)
+    isHidden.value = true
+  else if (dy < -6 || y < 120)
+    isHidden.value = false
+  lastScrollY = y
+}
+
+function onScroll() {
+  if (!ticking) {
+    ticking = true
+    requestAnimationFrame(applyScroll)
   }
 }
+
+onMounted(() => {
+  lastScrollY = window.scrollY
+  window.addEventListener('scroll', onScroll, { passive: true })
+})
+onUnmounted(() => window.removeEventListener('scroll', onScroll))
 </script>
 
 <template>
-  <div
-    class="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex items-end justify-between nav-wrapper"
-    :class="isVisible ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
+  <nav
+    class="flex items-center lg:hidden z-50 mbn-bar"
+    :class="isHidden ? 'mbn-bar--hidden' : ''"
+    aria-label="Основная навигация"
   >
-    <!-- Основная навигация: Главная, Каталог, Профиль -->
-    <nav class="floating-bar">
-      <!-- Скользящий pill -->
-      <div
-        v-if="activeIndex >= 0"
-        class="sliding-pill"
-        :style="{ left: `${activeIndex * 33.333}%` }"
-      />
+    <span v-if="activeIndex >= 0" class="mbn-lens" :style="lensStyle">
+      <span class="mbn-lens__pill" />
+    </span>
 
-      <NuxtLink
-        v-for="item in navItems"
-        :key="item.path"
-        :to="item.path"
-        class="nav-item"
-        @click="item.path === '/profile' ? handleProfileClick($event) : undefined"
+    <NuxtLink
+      v-for="item in displayItems"
+      :key="item.path"
+      v-slot="{ href, navigate }"
+      :to="item.path"
+      custom
+    >
+      <a
+        :href="href"
+        class="mbn-item"
+        :aria-label="item.label"
+        :aria-current="item.isActive ? 'page' : undefined"
+        @click="handleItemClick($event, item, navigate)"
       >
-        <Icon
-          :name="item.icon"
-          class="transition-all duration-300"
-          :class="isActive(item.path) ? 'w-7 h-7 text-blue-600' : 'w-6 h-6 text-gray-400'"
-          mode="svg"
-        />
-      </NuxtLink>
-    </nav>
-
-    <!-- Отдельная кнопка корзины справа -->
-    <NuxtLink to="/cart" class="cart-btn" :class="isCartActive ? 'cart-btn--active' : ''">
-      <div class="relative">
-        <Icon
-          name="streamline-plump:shopping-basket-1"
-          class="transition-all duration-300"
-          :class="isCartActive ? 'w-7 h-7 text-blue-600' : 'w-6 h-6 text-gray-400'"
-          mode="svg"
-        />
-        <ClientOnly>
-          <div
-            v-if="cartItemsCount > 0"
-            class="absolute -top-1.5 -right-1.5 bg-red-500 text-white text-[8px] font-bold rounded-full min-w-[16px] h-[16px] flex items-center justify-center px-0.5"
-          >
-            {{ cartItemsCount > 99 ? '99+' : cartItemsCount }}
-          </div>
-        </ClientOnly>
-      </div>
+        <span class="mbn-icon-wrap">
+          <Icon
+            :name="item.icon"
+            mode="svg"
+            class="mbn-icon transition-[transform,color] duration-300 ease-out"
+            :class="item.isActive ? 'text-primary scale-[1.18]' : 'text-muted-foreground scale-100'"
+          />
+          <span v-if="item.showBadge" class="mbn-badge">{{ item.badgeText }}</span>
+        </span>
+      </a>
     </NuxtLink>
-  </div>
+  </nav>
 </template>
 
 <style scoped>
-.nav-wrapper {
-  padding-bottom: env(safe-area-inset-bottom);
-  padding-left: 1.25rem;
-  padding-right: 1.25rem;
-  padding-top: 0.5rem;
-  gap: 0.625rem;
-  transition:
-    transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
-    opacity 0.35s cubic-bezier(0.4, 0, 0.2, 1);
-  pointer-events: none;
-}
-
-.floating-bar {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  flex: 1;
-  padding: 0.375rem;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.82);
-  backdrop-filter: blur(24px) saturate(180%);
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.6);
+.mbn-bar {
+  position: fixed;
+  left: 16px;
+  right: 16px;
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  height: 50px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.18));
+  backdrop-filter: blur(24px) saturate(1.9);
+  -webkit-backdrop-filter: blur(24px) saturate(1.9);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  border-radius: 22px;
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.1),
-    0 2px 8px rgba(0, 0, 0, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
-  pointer-events: all;
-  margin-bottom: 0.5rem;
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -1px 1px rgba(15, 23, 42, 0.05),
+    0 12px 32px rgba(15, 23, 42, 0.18);
+  transition:
+    opacity 0.28s ease,
+    transform 0.28s cubic-bezier(0.32, 0.72, 0.33, 1);
 }
 
-/* Скользящий pill по 3 пунктам */
-.sliding-pill {
-  position: absolute;
-  top: 0.375rem;
-  bottom: 0.375rem;
-  width: 33.333%;
-  border-radius: 18px;
-  background: rgba(59, 130, 246, 0.12);
-  transition: left 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+.mbn-bar--hidden {
+  opacity: 0;
   pointer-events: none;
+  transform: translateY(140%);
 }
 
-.nav-item {
+.mbn-lens {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 20%;
+  height: 100%;
+  display: grid;
+  place-content: center;
+  transition: transform 0.46s cubic-bezier(0.34, 1.12, 0.4, 1);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.mbn-lens__pill {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.5));
+  border: 1px solid rgba(255, 255, 255, 0.95);
+  box-shadow:
+    inset 0 2px 1px rgba(255, 255, 255, 1),
+    inset 0 -3px 5px rgba(15, 23, 42, 0.09),
+    0 7px 18px rgba(15, 23, 42, 0.22);
+}
+
+.mbn-item {
+  flex: 1;
+  min-width: 0;
   position: relative;
   z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 48px;
-  border-radius: 18px;
+  height: 100%;
+  display: grid;
+  place-content: center;
 }
 
-/* Отдельная кнопка корзины */
-.cart-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 60px;
-  height: 60px;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.82);
-  backdrop-filter: blur(24px) saturate(180%);
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.1),
-    0 2px 8px rgba(0, 0, 0, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
-  pointer-events: all;
-  margin-bottom: 0.5rem;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+.mbn-icon-wrap {
+  position: relative;
+  display: grid;
+  place-content: center;
+  width: 40px;
+  height: 40px;
 }
 
-.cart-btn--active {
-  background: rgba(59, 130, 246, 0.12);
-  border-color: rgba(59, 130, 246, 0.2);
+.mbn-icon {
+  width: 22px;
+  height: 22px;
+}
+
+.mbn-badge {
+  position: absolute;
+  top: -3px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #fff;
+  font: 700 10px var(--font-sans);
+  display: grid;
+  place-content: center;
+  border: 2px solid #fff;
 }
 </style>

--- a/components/global/ProductCard.vue
+++ b/components/global/ProductCard.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
-import type { CarouselApi } from '../ui/carousel'
 import type { BaseProduct } from '@/types'
 import { computed, ref } from 'vue'
 import StockAlertButton from '@/components/product/StockAlertButton.vue'
-import { Button } from '@/components/ui/button'
 import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
 import { useSeoAltText } from '@/composables/useSeoAltText'
 import { IMAGE_SIZES } from '@/config/images'
-import { BUCKET_NAME_BRANDS, BUCKET_NAME_PRODUCT } from '@/constants'
+import { BUCKET_NAME_PRODUCT } from '@/constants'
+import { useAuthStore } from '@/stores/auth'
+import { useModalStore } from '@/stores/modal/useModalStore'
 import { useCartStore } from '@/stores/publicStore/cartStore'
+import { useWishlistStore } from '@/stores/publicStore/wishlistStore'
 import { formatPrice } from '@/utils/formatPrice'
 
 const props = defineProps<{
@@ -16,86 +17,89 @@ const props = defineProps<{
 }>()
 
 const cartStore = useCartStore()
+const wishlistStore = useWishlistStore()
+const authStore = useAuthStore()
+const modalStore = useModalStore()
 const { getImageUrl, getVariantUrl } = useSupabaseStorage()
 const { triggerHaptic } = useHaptic()
-const { trackAddToCart } = useEcommerceTracking()
-const { generateProductImageAlt, generateBrandLogoAlt } = useSeoAltText()
+const { trackAddToCart, trackRemoveFromCart } = useEcommerceTracking()
+const { generateProductImageAlt } = useSeoAltText()
 
-// --- DEVICE DETECTION ---
-const isTouchDevice = ref(false)
-onMounted(() => {
-  isTouchDevice.value
-    = 'ontouchstart' in window || navigator.maxTouchPoints > 0
-})
+// --- ГАЛЕРЕЯ: единая scroll-snap лента (нативный свайп на тач, наведение мышью на десктопе) ---
+const scrollerRef = ref<HTMLElement | null>(null)
+const activeIndex = ref(0)
 
-// --- CAROUSEL STATE (для мобилы) ---
-const emblaMobileApi = ref<CarouselApi>()
-const mobileSelectedIndex = ref(0)
+const galleryImages = computed(() => props.product.product_images ?? [])
+const hasMultipleImages = computed(() => galleryImages.value.length > 1)
 
 /**
- * 🔑 Индексы слайдов, которые уже были показаны.
- * Изначально только [0] — первый слайд грузится сразу.
- * При свайпе добавляем текущий + следующий (предзагрузка на 1 вперёд).
+ * Индексы слайдов, для которых уже рендерим настоящую картинку (соседние тоже).
+ * Остальные — скелетон, чтобы не грузить всю галерею разом.
  */
 const visitedSlideIndexes = ref<Set<number>>(new Set([0]))
 
-function onMobileSelect() {
-  if (!emblaMobileApi.value)
-    return
-  const index = emblaMobileApi.value.selectedScrollSnap()
-  mobileSelectedIndex.value = index
-
+function markVisited(index: number) {
   visitedSlideIndexes.value.add(index)
-
-  // Предзагружаем следующий слайд
-  const nextIndex = index + 1
-  if (nextIndex < (props.product.product_images?.length ?? 0)) {
-    visitedSlideIndexes.value.add(nextIndex)
-  }
+  if (index - 1 >= 0)
+    visitedSlideIndexes.value.add(index - 1)
+  if (index + 1 < galleryImages.value.length)
+    visitedSlideIndexes.value.add(index + 1)
 }
 
-watch(emblaMobileApi, (api) => {
-  if (api) {
-    onMobileSelect()
-    api.on('select', onMobileSelect)
-    api.on('reInit', onMobileSelect)
+function onScroll(e: Event) {
+  const el = e.currentTarget as HTMLElement
+  if (!el || !el.clientWidth)
+    return
+
+  const index = Math.round(el.scrollLeft / el.clientWidth)
+  if (index !== activeIndex.value) {
+    activeIndex.value = index
   }
-})
-
-// --- CART STATE ---
-const itemInCart = computed(() => {
-  return cartStore.items.find(item => item.product.id === props.product.id)
-})
-
-const quantityInCart = computed(() => {
-  return itemInCart.value ? itemInCart.value.quantity : 0
-})
-
-// --- IMAGE STATE ---
-const activeImageIndex = ref(0)
-
-const hasMultipleImages = computed(
-  () =>
-    Array.isArray(props.product.product_images)
-    && props.product.product_images.length > 1,
-)
+  markVisited(index)
+}
 
 /**
- * Получить URL изображения по индексу
+ * Дэстоп: позиция курсора над картинкой напрямую управляет слайдом —
+ * ширина делится на количество фото, без клика и перетаскивания (как в WB/Ozon).
  */
+function onGalleryMouseMove(e: MouseEvent) {
+  const el = scrollerRef.value
+  if (!el || !hasMultipleImages.value)
+    return
+
+  const rect = el.getBoundingClientRect()
+  if (!rect.width)
+    return
+
+  const ratio = Math.min(Math.max((e.clientX - rect.left) / rect.width, 0), 0.999)
+  const index = Math.floor(ratio * galleryImages.value.length)
+
+  markVisited(index)
+  if (index !== activeIndex.value) {
+    activeIndex.value = index
+  }
+  el.scrollLeft = index * el.clientWidth
+}
+
+function onGalleryMouseLeave() {
+  const el = scrollerRef.value
+  if (!el || !hasMultipleImages.value)
+    return
+
+  activeIndex.value = 0
+  el.scrollLeft = 0
+}
+
 function getImageUrlByIndex(index: number): string | null {
-  const imageUrl = props.product.product_images?.[index]?.image_url
+  const imageUrl = galleryImages.value[index]?.image_url
   if (!imageUrl)
     return null
 
   return getImageUrl(BUCKET_NAME_PRODUCT, imageUrl, IMAGE_SIZES.CARD)
 }
 
-/**
- * Получить URL вариантов изображения (sm/md/lg) для srcset
- */
 function getVariantUrls(index: number) {
-  const imageUrl = props.product.product_images?.[index]?.image_url
+  const imageUrl = galleryImages.value[index]?.image_url
   if (!imageUrl)
     return {}
   return {
@@ -105,437 +109,272 @@ function getVariantUrls(index: number) {
   }
 }
 
-/**
- * SEO-оптимизированный alt текст для изображений
- */
 function getImageAlt(index: number): string {
-  const totalImages = props.product.product_images?.length || 1
+  const totalImages = galleryImages.value.length || 1
 
   return generateProductImageAlt({
     productName: props.product.name,
     brandName: props.product.brands?.name,
     lineName: props.product.product_line_name,
-    categoryName: props.product.categories?.name,
     index,
     totalImages,
   })
 }
 
-/**
- * Получить URL логотипа бренда
- */
-function getBrandLogoUrl(): string | null {
-  const logoUrl = props.product.brands?.logo_url
-  if (!logoUrl)
-    return null
-
-  return getVariantUrl(BUCKET_NAME_BRANDS, logoUrl, 'sm')
-}
-
-/**
- * Активное изображение для десктопа (наведение мышью)
- */
-const activeImageUrl = computed(() => {
-  return getImageUrlByIndex(activeImageIndex.value)
-})
-
-// --- MOUSE INTERACTION (только для десктопа) ---
-function handleMouseMove(event: MouseEvent) {
-  if (
-    !hasMultipleImages.value
-    || isTouchDevice.value
-    || !props.product.product_images
-  ) {
-    return
-  }
-
-  const target = event.currentTarget as HTMLElement
-  const rect = target.getBoundingClientRect()
-  const x = event.clientX - rect.left
-  const width = rect.width
-
-  if (width === 0)
-    return
-
-  const segmentWidth = width / props.product.product_images.length
-  const newIndex = Math.min(
-    Math.floor(x / segmentWidth),
-    props.product.product_images.length - 1,
-  )
-
-  if (newIndex !== activeImageIndex.value) {
-    activeImageIndex.value = newIndex
-  }
-}
-
-function handleMouseLeave() {
-  activeImageIndex.value = 0
-}
-
-// --- PRICE CALCULATION ---
+// --- ЦЕНА ---
 const priceDetails = computed(() => {
   const originalPrice = Number(props.product.price)
   const discountPercent = Number(props.product.discount_percentage)
-
   const hasDiscount = discountPercent > 0 && discountPercent <= 100
 
-  if (!hasDiscount) {
-    return {
-      hasDiscount: false,
-      finalPrice: originalPrice,
-    }
-  }
-
-  // 🔥 ЕДИНЫЙ ИСТОЧНИК ПРАВДЫ: final_price из базы данных (generated column)
-  // База автоматически применяет психологическое округление
-  const finalPrice = props.product.final_price
+  // 🔥 ЕДИНЫЙ ИСТОЧНИК ПРАВДЫ: final_price из базы данных (generated column,
+  // применяет психологическое округление)
+  const finalPrice = hasDiscount && props.product.final_price
     ? Number(props.product.final_price)
     : originalPrice
 
   return {
-    hasDiscount: true,
+    hasDiscount,
     finalPrice,
     originalPrice,
-    percent: Math.round(discountPercent),
+    percent: hasDiscount ? Math.round(discountPercent) : 0,
   }
 })
+
+const ratingLabel = computed(() => {
+  const rating = props.product.avg_rating
+  return rating != null ? rating.toFixed(1).replace('.', ',') : ''
+})
+
+const bonusLabel = computed(() => `+${formatPrice(props.product.bonus_points_award || 0)} бонусов`)
+
+const hasRating = computed(() =>
+  Boolean(props.product.review_count && props.product.review_count > 0 && props.product.avg_rating),
+)
+
+const hasBonus = computed(() =>
+  Boolean(props.product.bonus_points_award && props.product.bonus_points_award > 0),
+)
+
+const inStock = computed(() => Boolean(props.product.stock_quantity && props.product.stock_quantity > 0))
+
+// --- КОРЗИНА ---
+const itemInCart = computed(() => cartStore.items.find(item => item.product.id === props.product.id))
+const quantityInCart = computed(() => itemInCart.value?.quantity ?? 0)
+const maxAvailableQuantity = computed(() => Math.max(1, Math.floor((props.product.stock_quantity || 0) * 0.8)))
+
+function onAdd() {
+  cartStore.addItem(props.product as BaseProduct, 1)
+  trackAddToCart({ id: props.product.id, name: props.product.name, price: priceDetails.value.finalPrice })
+  triggerHaptic('medium')
+}
+
+function onInc() {
+  const next = quantityInCart.value + 1
+  if (next > maxAvailableQuantity.value)
+    return
+  cartStore.updateQuantity(props.product.id, next)
+  triggerHaptic('light')
+}
+
+function onDec() {
+  const next = quantityInCart.value - 1
+  if (next <= 0) {
+    trackRemoveFromCart({
+      id: props.product.id,
+      name: props.product.name,
+      price: priceDetails.value.finalPrice,
+      quantity: quantityInCart.value,
+    })
+  }
+  // updateQuantity сам удаляет позицию из корзины, если quantity <= 0
+  cartStore.updateQuantity(props.product.id, next)
+  triggerHaptic('light')
+}
+
+// --- ИЗБРАННОЕ ---
+const isWishlisted = computed(() => wishlistStore.isProductInWishlist(props.product.id))
+
+async function onWish() {
+  if (!authStore.isLoggedIn) {
+    modalStore.openLoginModal()
+    return
+  }
+  await wishlistStore.toggleWishlist(props.product.id, props.product.name)
+}
 </script>
 
 <template>
   <div
-    class="bg-white border rounded-xl overflow-hidden group transition-all hover:shadow-xl flex flex-col h-full"
+    class="pc-card flex h-full flex-col rounded-[20px] bg-white p-2.5"
+    :class="quantityInCart > 0 ? 'pc-card--active' : ''"
   >
     <!-- 🖼️ ГАЛЕРЕЯ ИЗОБРАЖЕНИЙ -->
-    <div
-      class="relative bg-white aspect-square overflow-hidden"
-      @mousemove="handleMouseMove"
-      @mouseleave="handleMouseLeave"
-    >
-      <!-- 🏷️ БЕЙДЖ СКИДКИ -->
-      <div v-if="priceDetails.hasDiscount" class="absolute top-3 right-3 z-10">
-        <Badge
-          variant="destructive"
-          class="font-bold text-xs px-2.5 py-1 shadow-lg"
+    <div class="relative aspect-square overflow-hidden rounded-xl bg-white">
+      <NuxtLink
+        :to="`/catalog/products/${product.slug}`"
+        class="absolute inset-0 block"
+      >
+        <div
+          v-if="galleryImages.length"
+          ref="scrollerRef"
+          class="pc-scroll flex h-full w-full select-none overflow-x-auto overflow-y-hidden [scroll-snap-type:x_mandatory] [touch-action:pan-x]"
+          @scroll="onScroll"
+          @mousemove="onGalleryMouseMove"
+          @mouseleave="onGalleryMouseLeave"
         >
-          -{{ priceDetails.percent }}%
-        </Badge>
-      </div>
-
-      <!-- 🚫 БЕЙДЖ "НЕТ В НАЛИЧИИ" -->
-      <div v-else-if="!product.stock_quantity || product.stock_quantity <= 0" class="absolute top-3 right-3 z-10">
-        <Badge
-          variant="secondary"
-          class="font-bold text-xs px-2.5 py-1 shadow-lg bg-gray-500 text-white"
-        >
-          Нет в наличии
-        </Badge>
-      </div>
-
-      <!-- ❤️ КНОПКА ДОБАВЛЕНИЯ В ИЗБРАННОЕ -->
-      <div class="absolute top-3 left-3 z-10">
-        <ProductWishlistButton
-          :product-id="product.id"
-          :product-name="product.name"
-        />
-      </div>
-
-      <ClientOnly>
-        <!-- 🖥️ ДЕСКТОП: Наведение мышью меняет изображение -->
-        <template v-if="!isTouchDevice">
-          <NuxtLink
-            :to="`/catalog/products/${product.slug}`"
-            class="block h-full p-4"
+          <div
+            v-for="(image, index) in galleryImages"
+            :key="`slide-${index}`"
+            class="h-full w-full shrink-0 [scroll-snap-align:center]"
           >
             <ProgressiveImage
-              :src="activeImageUrl"
-              :src-sm="getVariantUrls(activeImageIndex).sm"
-              :src-md="getVariantUrls(activeImageIndex).md"
-              :src-lg="getVariantUrls(activeImageIndex).lg"
+              v-if="visitedSlideIndexes.has(index)"
+              :src="getImageUrlByIndex(index)"
+              :src-sm="getVariantUrls(index).sm"
+              :src-md="getVariantUrls(index).md"
+              :src-lg="getVariantUrls(index).lg"
               sizes="(max-width: 767px) 50vw, (max-width: 1024px) 33vw, 25vw"
-              :alt="getImageAlt(activeImageIndex)"
-              aspect-ratio="1/1"
+              :alt="getImageAlt(index)"
+              aspect-ratio="square"
               object-fit="contain"
               placeholder-type="lqip"
-              :blur-data-url="
-                product.product_images?.[activeImageIndex]?.blur_placeholder
-              "
-              eager
-              zoom-on-hover
+              :blur-data-url="image.blur_placeholder"
+              :eager="index === 0"
             />
-          </NuxtLink>
-        </template>
+            <div v-else class="h-full w-full animate-pulse bg-muted" aria-hidden="true" />
+          </div>
+        </div>
 
-        <!-- 📱 МОБИЛ: Карусель изображений -->
-        <template v-else>
-          <Carousel
-            v-if="hasMultipleImages"
-            class="w-full h-full"
-            :opts="{ loop: true, align: 'start' }"
-            @touchstart.stop
-            @touchmove.stop
-            @touchend.stop
-            @init-api="(val) => (emblaMobileApi = val)"
-          >
-            <CarouselContent>
-              <CarouselItem
-                v-for="(image, index) in product.product_images"
-                :key="`carousel-${index}`"
-              >
-                <NuxtLink
-                  :to="`/catalog/products/${product.slug}`"
-                  class="block h-full aspect-square p-4"
-                >
-                  <!--
-                    🔑 ЛЕНИВАЯ ЗАГРУЗКА КАРУСЕЛИ:
-                    Рендерим ProgressiveImage только для посещённых слайдов.
-                    visitedSlideIndexes изначально = [0], при свайпе добавляем
-                    текущий + следующий индекс.
-                    Непосещённые слайды — лёгкий скелетон без сетевых запросов.
-                  -->
-                  <ProgressiveImage
-                    v-if="visitedSlideIndexes.has(index)"
-                    :src="getImageUrlByIndex(index)"
-                    :src-sm="getVariantUrls(index).sm"
-                    :src-md="getVariantUrls(index).md"
-                    :src-lg="getVariantUrls(index).lg"
-                    sizes="(max-width: 767px) 50vw, (max-width: 1024px) 33vw, 25vw"
-                    :alt="getImageAlt(index)"
-                    aspect-ratio="1/1"
-                    object-fit="contain"
-                    placeholder-type="lqip"
-                    :blur-data-url="image.blur_placeholder"
-                    :eager="index === 0"
-                    zoom-on-hover
-                  />
+        <div v-else class="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+          📷 Нет фото
+        </div>
+      </NuxtLink>
 
-                  <!-- Скелетон для ещё не посещённых слайдов -->
-                  <div
-                    v-else
-                    class="w-full h-full bg-muted animate-pulse rounded-lg"
-                    aria-hidden="true"
-                  />
-                </NuxtLink>
-              </CarouselItem>
-            </CarouselContent>
-          </Carousel>
+      <!-- 🆕 Новинка -->
+      <Badge
+        v-if="product.is_new"
+        variant="secondary"
+        class="pointer-events-none absolute left-2.5 top-2.5 z-10 rounded-full border-transparent bg-success px-2.5 py-1 text-[11.5px] font-bold text-white shadow-lg"
+      >
+        Новинка
+      </Badge>
 
-          <!-- 📷 Одно изображение на мобилке -->
-          <NuxtLink
-            v-else
-            :to="`/catalog/products/${product.slug}`"
-            class="block h-full p-4"
-          >
-            <ProgressiveImage
-              v-if="activeImageUrl"
-              :src="activeImageUrl"
-              :src-sm="getVariantUrls(0).sm"
-              :src-md="getVariantUrls(0).md"
-              :src-lg="getVariantUrls(0).lg"
-              sizes="(max-width: 767px) 50vw, (max-width: 1024px) 33vw, 25vw"
-              :alt="getImageAlt(0)"
-              aspect-ratio="1/1"
-              object-fit="contain"
-              placeholder-type="shimmer"
-              eager
-              zoom-on-hover
-            />
-            <div
-              v-else
-              class="w-full h-full flex items-center justify-center text-muted-foreground text-sm"
-            >
-              📷 Нет фото
-            </div>
-          </NuxtLink>
-        </template>
+      <!-- 🏷️ Скидка -->
+      <Badge
+        v-if="priceDetails.hasDiscount"
+        variant="destructive"
+        class="pointer-events-none absolute bottom-2.5 left-2.5 z-10 rounded-full px-[11px] py-[5px] text-[13px] font-extrabold shadow-lg"
+      >
+        −{{ priceDetails.percent }}%
+      </Badge>
 
-        <!-- ⚙️ Fallback для SSR -->
-        <template #fallback>
-          <NuxtLink
-            :to="`/catalog/products/${product.slug}`"
-            class="block h-full p-4"
-          >
-            <ProgressiveImage
-              v-if="activeImageUrl"
-              :src="activeImageUrl"
-              :src-sm="getVariantUrls(0).sm"
-              :src-md="getVariantUrls(0).md"
-              :src-lg="getVariantUrls(0).lg"
-              sizes="(max-width: 767px) 50vw, (max-width: 1024px) 33vw, 25vw"
-              :alt="getImageAlt(0)"
-              aspect-ratio="1/1"
-              object-fit="contain"
-              placeholder-type="shimmer"
-              eager
-              zoom-on-hover
-            />
-            <div
-              v-else
-              class="w-full h-full flex items-center justify-center text-muted-foreground text-sm"
-            >
-              📷 Нет фото
-            </div>
-          </NuxtLink>
-        </template>
-      </ClientOnly>
+      <!-- ❤️ Избранное -->
+      <button
+        type="button"
+        aria-label="В избранное"
+        class="pc-wish absolute right-2 top-2 z-[3] grid size-[38px] place-content-center rounded-full"
+        @click.stop.prevent="onWish"
+      >
+        <Icon
+          :name="isWishlisted ? 'line-md:heart-filled' : 'line-md:heart'"
+          class="size-[21px]"
+          :class="isWishlisted ? 'text-red-500' : 'text-muted-foreground'"
+        />
+      </button>
 
-      <!-- 🔵 ИНДИКАТОРЫ-ТОЧКИ -->
+      <!-- 🔵 Индикаторы -->
       <div
         v-if="hasMultipleImages"
-        class="absolute bottom-3 left-0 right-0 flex justify-center items-center gap-1.5 pointer-events-none"
+        class="pointer-events-none absolute inset-x-0 bottom-[9px] z-[2] flex items-center justify-center gap-[5px]"
       >
-        <ClientOnly>
-          <!-- Десктоп индикаторы -->
-          <template v-if="!isTouchDevice">
-            <div
-              v-for="(_, index) in product.product_images"
-              :key="`dot-desktop-${index}`"
-              class="rounded-full transition-all"
-              :class="
-                index === activeImageIndex
-                  ? 'w-5 h-1.5 bg-gray-600'
-                  : 'w-1.5 h-1.5 bg-gray-300'
-              "
-            />
-          </template>
-
-          <!-- Мобил индикаторы -->
-          <template v-else>
-            <div
-              v-for="(_, index) in product.product_images"
-              :key="`dot-mobile-${index}`"
-              class="rounded-full transition-all"
-              :class="
-                index === mobileSelectedIndex
-                  ? 'w-5 h-1.5 bg-gray-600'
-                  : 'w-1.5 h-1.5 bg-gray-300'
-              "
-            />
-          </template>
-        </ClientOnly>
+        <span
+          v-for="(_, index) in galleryImages"
+          :key="`dot-${index}`"
+          class="h-1.5 rounded-full shadow-[0_1px_3px_rgb(0_0_0_/_0.3)] transition-[width] duration-200"
+          :class="index === activeIndex ? 'w-4 bg-white' : 'w-1.5 bg-white/60'"
+        />
       </div>
     </div>
 
     <!-- 📋 ИНФОРМАЦИЯ О ТОВАРЕ -->
-    <div class="p-4 space-y-3 flex-grow flex flex-col">
-      <!-- 🏢 Бренд -->
-      <div v-if="product.brands" class="min-h-[16px]">
-        <NuxtLink
-          :to="`/brand/${product.brands.slug}`"
-          class="flex items-center gap-2 group"
-          @click.stop
-        >
-          <!-- Логотип бренда -->
-          <div
-            v-if="getBrandLogoUrl()"
-            class="w-8 h-8 flex items-center justify-center rounded border border-border/50 group-hover:border-primary/30 transition-colors bg-background overflow-hidden flex-shrink-0"
-          >
-            <ProgressiveImage
-              :src="getBrandLogoUrl()!"
-              :alt="generateBrandLogoAlt(product.brands.name)"
-              object-fit="contain"
-              placeholder-type="shimmer"
-              class="w-full h-full p-0.5"
-            />
-          </div>
-          <!-- Название бренда -->
-          <span
-            class="text-xs text-muted-foreground group-hover:text-primary transition-colors font-medium line-clamp-1"
-          >
-            {{ product.brands.name }}
-          </span>
-        </NuxtLink>
-      </div>
-
-      <!-- 📦 Серия -->
-      <span
-        v-if="product.product_line_name"
-        class="text-[11px] text-pink-600 font-medium"
-      >
-        {{ product.product_line_name }}
-      </span>
-
-      <!-- 📝 Название товара -->
+    <div class="flex flex-1 flex-col gap-[7px] px-[5px] pb-[3px] pt-[11px]">
+      <!-- 📝 Название -->
       <NuxtLink :to="`/catalog/products/${product.slug}`" class="block">
-        <h3
-          class="font-semibold text-sm leading-tight line-clamp-2 hover:text-primary transition-colors"
-        >
+        <h3 class="line-clamp-2 min-h-[38px] text-[14px] font-normal leading-[1.35] text-foreground">
           {{ product.name }}
         </h3>
       </NuxtLink>
 
-      <!-- 💰 Цена и бонусы -->
-      <div class="space-y-1 mt-auto">
-        <div class="flex items-baseline gap-2">
-          <p class="text-xl font-bold text-primary">
-            {{ formatPrice(priceDetails.finalPrice) }} ₸
-          </p>
-          <p
-            v-if="priceDetails.hasDiscount"
-            class="text-sm text-muted-foreground line-through"
-          >
-            {{ formatPrice(priceDetails.originalPrice) }} ₸
-          </p>
-        </div>
-
-        <!-- Бонусы -->
-        <Badge
-          v-if="product.bonus_points_award && product.bonus_points_award > 0"
-          variant="secondary"
-          class="inline-flex items-center gap-1 bg-orange-50 text-orange-600 hover:bg-orange-100 border-orange-200"
-        >
-          <Icon name="lucide:gift" class="w-3 h-3" />
-          <span>+{{ product.bonus_points_award }} бонусов</span>
-        </Badge>
+      <!-- ⭐ Рейтинг -->
+      <div v-if="hasRating" class="flex items-center gap-[5px] text-[13px] font-bold text-foreground">
+        <Icon name="gravity-ui:star-fill" class="size-3.5 shrink-0 text-rating" />
+        <span>{{ ratingLabel }}</span>
+        <span class="font-medium text-muted-foreground">· {{ product.review_count }}</span>
       </div>
 
-      <!-- 🛒 КНОПКА ДОБАВЛЕНИЯ В КОРЗИНУ -->
-      <div class="pt-3 space-y-2">
-        <!-- ⭐ Рейтинг и отзывы (Marketplace Style) -->
-        <div
-          v-if="
-            product.review_count
-              && product.review_count > 0
-              && product.avg_rating
-          "
-          class="flex items-center gap-1.5"
-        >
-          <!-- ✨ Новая стилизованная иконка -->
-          <Icon
-            name="gravity-ui:star-fill"
-            class="w-3.5 h-3.5 shrink-0 text-yellow-400"
-          />
+      <!-- 🎁 Бонусы -->
+      <div
+        v-if="hasBonus"
+        class="inline-flex items-center gap-[7px] self-start rounded-lg bg-gradient-to-r from-orange-50 to-orange-100 px-[11px] py-[7px] text-[13px] font-bold"
+      >
+        <Icon name="lucide:gift" class="size-3.5 shrink-0 text-orange-500" />
+        <span class="bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text text-transparent">
+          {{ bonusLabel }}
+        </span>
+      </div>
 
-          <!-- Оценка через запятую -->
-          <span class="text-sm font-bold text-foreground leading-none pt-0.5">
-            {{ product.avg_rating.toFixed(1).replace(".", ",") }}
-          </span>
-
-          <!-- Количество отзывов через точку -->
-          <span class="text-xs text-muted-foreground leading-none pt-0.5">
-            <span class="mx-0.5 opacity-50">·</span>{{ product.review_count }}
-          </span>
-        </div>
-
+      <!-- 🛒 ПОКУПКА -->
+      <div class="mt-auto pt-[5px]">
         <ClientOnly>
-          <template v-if="product.stock_quantity && product.stock_quantity > 0">
-            <Button
-              v-if="!itemInCart"
-              class="w-full h-10 font-semibold"
-              @click="() => { 
-                cartStore.addItem(product as BaseProduct, 1); 
-                trackAddToCart({ id: product.id, name: product.name, price: priceDetails.finalPrice });
-                triggerHaptic('medium'); 
-              }"
+          <template v-if="inStock">
+            <div
+              v-if="quantityInCart > 0"
+              class="pc-stepper flex h-[52px] items-center justify-between rounded-full px-[7px]"
             >
-              <Icon name="lucide:shopping-cart" class="w-4 h-4 mr-2" />
-              В корзину
-            </Button>
+              <button
+                type="button"
+                aria-label="Уменьшить количество"
+                class="pc-stepper-btn grid size-[38px] place-content-center rounded-full"
+                @click="onDec"
+              >
+                <Icon name="lucide:minus" class="size-[17px]" />
+              </button>
+              <span class="flex-1 text-center text-[15px] font-extrabold text-white">{{ quantityInCart }} шт</span>
+              <button
+                type="button"
+                aria-label="Увеличить количество"
+                class="pc-stepper-btn grid size-[38px] place-content-center rounded-full"
+                @click="onInc"
+              >
+                <Icon name="lucide:plus" class="size-[17px]" />
+              </button>
+            </div>
 
-            <QuantitySelector
-              v-else
-              :product="product"
-              :quantity="quantityInCart"
-            />
+            <div v-else class="flex h-[52px] items-center justify-between gap-2 rounded-full bg-muted pl-4 pr-[5px]">
+              <span class="flex flex-col justify-center leading-tight">
+                <span
+                  v-if="priceDetails.hasDiscount"
+                  class="text-[13px] font-medium text-muted-foreground line-through"
+                >
+                  {{ formatPrice(priceDetails.originalPrice) }} ₸
+                </span>
+                <span
+                  class="text-[17px] font-extrabold"
+                  :class="priceDetails.hasDiscount ? 'text-discount' : 'text-foreground'"
+                >
+                  {{ formatPrice(priceDetails.finalPrice) }} ₸
+                </span>
+              </span>
+              <button
+                type="button"
+                aria-label="В корзину"
+                class="pc-add grid size-11 shrink-0 place-content-center rounded-full"
+                @click="onAdd"
+              >
+                <Icon name="lucide:plus" class="size-[26px]" />
+              </button>
+            </div>
           </template>
 
           <template v-else>
@@ -543,13 +382,97 @@ const priceDetails = computed(() => {
           </template>
 
           <template #fallback>
-            <Button class="w-full h-10" disabled>
-              <Icon name="lucide:loader-2" class="w-4 h-4 mr-2 animate-spin" />
-              Загрузка...
-            </Button>
+            <div class="h-[52px] animate-pulse rounded-full bg-muted" />
           </template>
         </ClientOnly>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.pc-card {
+  border: 1px solid rgb(255 255 255 / 0.92);
+  box-shadow:
+    inset 0 1.5px 0 rgb(255 255 255 / 0.98),
+    inset 0 -2px 4px rgb(15 23 42 / 0.07),
+    inset 0 0 0 1px rgb(255 255 255 / 0.5),
+    0 1px 0 rgb(15 23 42 / 0.05);
+  transition:
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
+}
+.pc-card--active {
+  border-color: var(--primary);
+  box-shadow:
+    inset 0 0 0 1px var(--primary),
+    inset 0 1.5px 0 rgb(255 255 255 / 0.98),
+    inset 0 -2px 4px rgb(15 23 42 / 0.07),
+    inset 0 0 0 1px rgb(255 255 255 / 0.5),
+    0 1px 0 rgb(15 23 42 / 0.05);
+}
+
+.pc-scroll {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.pc-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+/* ВНИМАНИЕ: у .pc-wish и .pc-add НЕТ backdrop-filter — и добавлять его сюда нельзя.
+   Карточка живёт в каруселях и сетках по 18+ штук на экран, а backdrop-filter
+   заставляет браузер переснимать и блюрить подложку на каждом кадре. Замер на
+   главной (390px, CPU ×6): с блюром медиана кадра 47.6ms / 42% кадров >50ms,
+   без него — 24.9ms / 11%. При быстром скролле секции успевали «пропасть и
+   появиться». Непрозрачность градиента ниже и так 85–95%, размытия за ним
+   почти не видно. Стекло оставлено только там, где оно читается: шапка,
+   липкая строка, нижняя навигация, deal-карточка. */
+.pc-wish {
+  border: 1px solid rgb(255 255 255 / 0.8);
+  background: linear-gradient(150deg, rgb(255 255 255 / 0.92), rgb(255 255 255 / 0.7));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.9),
+    0 4px 12px rgb(15 23 42 / 0.14);
+  transition: transform 0.12s ease;
+}
+.pc-wish:hover {
+  transform: scale(1.1);
+}
+
+.pc-add {
+  border: 1px solid rgb(255 255 255 / 0.9);
+  background: linear-gradient(150deg, rgb(255 255 255 / 0.97), rgb(224 233 247 / 0.85));
+  box-shadow:
+    inset 0 1px 0 #fff,
+    0 4px 12px rgb(43 127 255 / 0.2);
+  color: var(--primary);
+  transition: background 0.12s ease;
+}
+.pc-add:hover {
+  background: linear-gradient(150deg, #fff, rgb(191 219 254 / 0.75));
+}
+
+.pc-stepper {
+  border: 1px solid rgb(255 255 255 / 0.45);
+  background: linear-gradient(150deg, rgb(77 148 255 / 0.95), rgb(23 101 235 / 0.85));
+  backdrop-filter: blur(12px) saturate(1.7);
+  -webkit-backdrop-filter: blur(12px) saturate(1.7);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.5),
+    inset 0 -2px 8px rgb(6 53 138 / 0.28),
+    0 8px 20px rgb(43 127 255 / 0.3);
+}
+
+.pc-stepper-btn {
+  background: rgb(255 255 255 / 0.26);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.45);
+  color: #fff;
+  transition: background 0.12s ease;
+}
+.pc-stepper-btn:hover {
+  background: rgb(255 255 255 / 0.38);
+}
+</style>

--- a/components/global/ProductCarousel.vue
+++ b/components/global/ProductCarousel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { BaseProduct } from '@/types'
-import { carouselContainerVariants } from '@/lib/variants'
+import { carouselContainerVariants, sectionSpacingVariants } from '@/lib/variants'
 
 defineProps<{
   products: BaseProduct[] | null
@@ -12,52 +12,59 @@ const carouselContainerClass = carouselContainerVariants({ contained: 'desktop' 
 </script>
 
 <template>
-  <section v-if="products && products.length > 0" class="py-8 md:py-12">
-    <!-- `container` нужен только для заголовка -->
+  <section v-if="products && products.length > 0" :class="sectionSpacingVariants({ size: 'sm' })">
+    <!-- Заголовок — в обычном контейнере страницы -->
     <div :class="headerContainerClass">
       <slot name="header" />
     </div>
 
     <!--
-      Обертка `overflow-hidden` важна, чтобы спрятать горизонтальный скроллбар,
-      который может появиться из-за отрицательного margin.
+      Лента. Компонент самодостаточен по ширине — снаружи его оборачивать
+      в контейнер НЕ нужно (иначе получится двойной padding).
+
+      ВАЖНО: до lg на самой карусели бокового padding'а быть НЕ должно —
+      её корень совпадает с окном прокрутки (overflow-hidden внутри
+      CarouselContent), и любой padding здесь стал бы мёртвой полосой,
+      в которой карточки пропадали бы, не доезжая до края экрана.
+      Отступ живёт на флекс-ленте (см. CarouselContent ниже): в состоянии
+      покоя первая карточка стоит по gutter'у, а при листании карточки
+      проезжают под ним от края до края.
+      На lg+ `carouselContainerClass` добавляет padding с обеих сторон —
+      лента становится вровень с контейнером страницы.
     -->
     <div class="overflow-hidden">
-      <div
-        class="
-          pl-0 -mr-2 sm:-mr-6 lg:mx-auto
-        "
+      <Carousel
+        class="w-full"
+        :class="carouselContainerClass"
+        :opts="{
+          align: 'start',
+        }"
       >
-        <Carousel
-          class="w-full"
-          :class="carouselContainerClass"
-          :opts="{
-            align: 'start',
-          }"
-        >
-          <!--
-          `pl-4 sm:pl-6 lg:pl-8` - этот padding должен соответствовать padding'у вашего .container,
-          чтобы первый элемент был выровнен по левому краю.
-          `-ml-4` компенсирует `pl-4` на `CarouselItem`.
+        <!--
+          `pl-[var(--page-gutter)]` (до lg — там padding уже на контейнере)
+          ставит первую карточку по gutter'у, а отрицательные margin'ы гасят
+          её собственные отступы (`pl-2` у CarouselItem + `p-1` у обёртки):
+          слева 12px до md и 4px после (там pl-0), справа всегда 4px — иначе
+          в конце ленты последняя карточка не доезжает до края на эти 4px.
+          Итог — видимый край карточки ровно на краю с обеих сторон.
         -->
-          <CarouselContent class="-ml-1">
-            <CarouselItem
-              v-for="product in products"
-              :key="product.id"
-              class="pl-2 md:pl-0
+        <CarouselContent class="pl-[var(--page-gutter)] lg:pl-0 -ml-3 md:-ml-1 -mr-1">
+          <CarouselItem
+            v-for="product in products"
+            :key="product.id"
+            class="pl-2 md:pl-0
                    basis-[52.63%]
                    sm:basis-[45%]
                    md:basis-[30%]
                    lg:basis-[22%]
                    xl:basis-[18%]"
-            >
-              <div class="p-1 h-full">
-                <ProductCard :product="product" class="h-full" />
-              </div>
-            </CarouselItem>
-          </CarouselContent>
-        </Carousel>
-      </div>
+          >
+            <div class="p-1 h-full">
+              <ProductCard :product="product" class="h-full" />
+            </div>
+          </CarouselItem>
+        </CarouselContent>
+      </Carousel>
     </div>
   </section>
 </template>

--- a/components/global/ProductCarouselSectionSkeleton.vue
+++ b/components/global/ProductCarouselSectionSkeleton.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { Skeleton } from '@/components/ui/skeleton'
+import { carouselContainerVariants, sectionSpacingVariants } from '@/lib/variants'
+
+/**
+ * Скелетон ЦЕЛОЙ секции с каруселью товаров (отступы + заголовок + лента).
+ *
+ * Существует ровно для того, чтобы «пустое» состояние совпадало с готовой
+ * секцией по всем трём осям:
+ *   • вертикальные отступы — py-4 (обёртка ProductsCarousel) + py-8 (ProductCarousel);
+ *   • ширина заголовка — контейнер 'always';
+ *   • геометрия ленты — контейнер 'desktop', а боковой отступ внутри
+ *     ProductCarouselSkeleton, ровно как в ProductCarousel.
+ * Иначе при переходе skeleton → карусель контент дёргается.
+ *
+ * title не передан (лента ещё не смонтирована и заголовок неизвестен) —
+ * вместо <h2> рисуется серая плашка.
+ */
+defineProps<{
+  title?: string
+}>()
+
+const headerContainerClass = carouselContainerVariants({ contained: 'always' })
+const carouselContainerClass = carouselContainerVariants({ contained: 'desktop' })
+</script>
+
+<template>
+  <div :class="sectionSpacingVariants({ size: 'xs' })">
+    <div :class="sectionSpacingVariants({ size: 'sm' })">
+      <div :class="headerContainerClass">
+        <div class="flex justify-between items-center mb-8">
+          <h2 v-if="title" class="text-xl md:text-3xl font-bold tracking-tight">
+            {{ title }}
+          </h2>
+          <Skeleton v-else class="h-8 w-1/3 rounded-lg" />
+        </div>
+      </div>
+
+      <div class="overflow-hidden">
+        <div class="w-full" :class="carouselContainerClass">
+          <ProductCarouselSkeleton />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/global/ProductCarouselSkeleton.vue
+++ b/components/global/ProductCarouselSkeleton.vue
@@ -5,32 +5,36 @@ import { Skeleton } from '@/components/ui/skeleton'
 <template>
   <div class="overflow-hidden">
     <!--
-      Используем `flex`, чтобы имитировать поведение карусели.
-      `pl-*` имитируют отступы контейнера.
+      Геометрия ленты обязана 1-в-1 повторять ProductCarousel.vue
+      (padding, отрицательный margin и basis у слайдов), иначе при переходе
+      skeleton → карусель карточки прыгают по горизонтали. Боковой отступ —
+      здесь, а не на обёртке: обёртка = окно прокрутки, оно full-bleed.
     -->
-    <div class="flex -ml-2 pl-0">
+    <div class="flex pl-[var(--page-gutter)] lg:pl-0 -ml-3 md:-ml-1 -mr-1">
       <!-- Рендерим 6 карточек-заглушек, чтобы заполнить даже большие экраны -->
       <div
         v-for="n in 6"
         :key="n"
-        class="pl-4 shrink-0
+        class="pl-2 md:pl-0 shrink-0
                basis-[52.63%]
                sm:basis-[45%]
                md:basis-[30%]
                lg:basis-[22%]
                xl:basis-[18%]"
       >
-        <!-- Внутренняя структура карточки - такая же, как в ProductGridSkeleton -->
-        <div class="border rounded-lg overflow-hidden bg-card flex flex-col">
-          <Skeleton class="aspect-square w-full" />
-          <div class="p-4 space-y-3 flex-grow flex flex-col">
-            <Skeleton class="h-5 w-3/4" />
-            <div class="flex items-baseline justify-between">
-              <Skeleton class="h-6 w-1/3" />
-              <Skeleton class="h-4 w-1/4" />
-            </div>
-            <div class="mt-auto pt-2">
-              <Skeleton class="h-10 w-full rounded-md" />
+        <div class="p-1 h-full">
+          <!-- Внутренняя структура карточки - такая же, как в ProductGridSkeleton -->
+          <div class="border rounded-lg overflow-hidden bg-card flex flex-col">
+            <Skeleton class="aspect-square w-full" />
+            <div class="p-4 space-y-3 flex-grow flex flex-col">
+              <Skeleton class="h-5 w-3/4" />
+              <div class="flex items-baseline justify-between">
+                <Skeleton class="h-6 w-1/3" />
+                <Skeleton class="h-4 w-1/4" />
+              </div>
+              <div class="mt-auto pt-2">
+                <Skeleton class="h-10 w-full rounded-md" />
+              </div>
             </div>
           </div>
         </div>

--- a/components/home/BestsellersGrid.vue
+++ b/components/home/BestsellersGrid.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import type { ProductWithGallery } from '@/types'
+import { sectionSpacingVariants } from '@/lib/variants'
+import { useProductsStore } from '@/stores/publicStore/productsStore'
+
+/**
+ * «Хиты продаж» — сетка товаров + «Показать ещё» (Homepage.dc.html: hits grid).
+ *
+ * Сама пагинирует через productsStore.fetchProducts(sortBy:'popularity');
+ * hasMore из ответа управляет видимостью кнопки. Сетка своя (не глобальный
+ * ProductGrid — его нельзя менять, 5+ потребителей), т.к. здесь карточки
+ * мельче: 5 колонок на десктопе вместо стандартных 4.
+ */
+const PAGE_SIZE = 8
+
+const productsStore = useProductsStore()
+
+const products = ref<ProductWithGallery[]>([])
+const page = ref(0)
+const hasMore = ref(true)
+const isLoading = ref(false)
+
+async function loadMore() {
+  if (isLoading.value || !hasMore.value)
+    return
+  isLoading.value = true
+  try {
+    const next = page.value + 1
+    const res = await productsStore.fetchProducts(
+      { categorySlug: 'all', sortBy: 'popularity' },
+      next,
+      PAGE_SIZE,
+    )
+    products.value.push(...res.products)
+    hasMore.value = res.hasMore
+    page.value = next
+  }
+  catch (error) {
+    console.error('❌ Не удалось загрузить хиты продаж:', error)
+    hasMore.value = false
+  }
+  finally {
+    isLoading.value = false
+  }
+}
+
+const showSkeleton = computed(() => isLoading.value && products.value.length === 0)
+const countLabel = computed(() =>
+  products.value.length ? `${products.value.length}+ товаров` : '',
+)
+
+onMounted(loadMore)
+</script>
+
+<template>
+  <section :class="sectionSpacingVariants({ size: 'xs' })">
+    <div class="flex items-baseline gap-3 mb-5">
+      <h2 class="m-0 font-bold tracking-tight text-[clamp(22px,3vw,32px)]">
+        Хиты продаж
+      </h2>
+      <span v-if="countLabel" class="text-sm text-muted-foreground font-medium">{{ countLabel }}</span>
+    </div>
+
+    <div v-if="showSkeleton" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+      <div
+        v-for="i in PAGE_SIZE"
+        :key="i"
+        class="aspect-[3/4] rounded-xl bg-muted animate-pulse"
+      />
+    </div>
+
+    <template v-else>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+        <ProductCard
+          v-for="product in products"
+          :key="product.id"
+          :product="product"
+        />
+      </div>
+
+      <div v-if="hasMore" class="flex justify-center mt-6">
+        <Button
+          variant="outline"
+          size="lg"
+          :disabled="isLoading"
+          class="min-w-[220px]"
+          @click="loadMore"
+        >
+          <Icon v-if="isLoading" name="lucide:loader-2" class="size-4 animate-spin" />
+          {{ isLoading ? 'Загружаем…' : 'Показать ещё' }}
+        </Button>
+      </div>
+    </template>
+  </section>
+</template>

--- a/components/home/BrandsRail.vue
+++ b/components/home/BrandsRail.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import type { Database } from '@/types'
+import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
+import { BUCKET_NAME_BRANDS } from '@/constants'
+import { sectionSpacingVariants } from '@/lib/variants'
+
+/**
+ * «Популярные бренды» (Homepage.dc.html: секция brands).
+ *
+ * Горизонтальная лента логотипов в рамках. Источник — таблица brands
+ * (метрики популярности у брендов нет; алфавит + limit — существующий
+ * продовый компромисс, тот же, что в BrandsCollapsible).
+ */
+const supabase = useSupabaseClient<Database>()
+const { getVariantUrl } = useSupabaseStorage()
+
+const { data: brands } = await useAsyncData(
+  'home-brands-rail',
+  async () => {
+    const { data, error } = await supabase
+      .from('brands')
+      .select('id, name, slug, logo_url, blur_placeholder')
+      .order('name')
+      .limit(20)
+    if (error) {
+      console.error('❌ Не удалось загрузить бренды:', error)
+      return []
+    }
+    return data ?? []
+  },
+  { server: false, lazy: true, default: () => [] },
+)
+
+function logoOf(logoUrl: string | null): string | null {
+  if (!logoUrl)
+    return null
+  return getVariantUrl(BUCKET_NAME_BRANDS, logoUrl, 'sm') || null
+}
+</script>
+
+<template>
+  <section v-if="brands && brands.length" :class="sectionSpacingVariants({ size: 'xs' })">
+    <div class="flex items-center justify-between gap-3 mb-4">
+      <div class="flex flex-col gap-1">
+        <h2 class="m-0 font-bold tracking-tight text-[clamp(22px,3vw,32px)]">
+          Популярные бренды
+        </h2>
+        <p class="m-0 text-sm text-muted-foreground">
+          Работаем только с проверенными производителями детских товаров
+        </p>
+      </div>
+      <NuxtLink to="/brands" class="brands-cta brands-cta--desktop">
+        Все бренды
+        <Icon name="lucide:arrow-right" class="size-4" />
+      </NuxtLink>
+    </div>
+
+    <div class="brands-scroll hs">
+      <div class="brands-wrap">
+        <NuxtLink
+          v-for="brand in brands"
+          :key="brand.id"
+          :to="`/brand/${brand.slug}`"
+          :title="brand.name"
+          class="brand-card"
+        >
+          <img
+            v-if="logoOf(brand.logo_url)"
+            :src="logoOf(brand.logo_url)!"
+            :alt="brand.name"
+            loading="lazy"
+            class="brand-card__logo"
+          >
+          <span v-else class="brand-card__fallback">{{ brand.name }}</span>
+        </NuxtLink>
+      </div>
+    </div>
+
+    <NuxtLink to="/brands" class="brands-cta brands-cta--mobile">
+      Все бренды
+      <Icon name="lucide:arrow-right" class="size-[17px]" />
+    </NuxtLink>
+  </section>
+</template>
+
+<style scoped>
+.brands-cta {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: none;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background 0.15s ease,
+    transform 0.1s ease;
+}
+
+.brands-cta:hover {
+  background: var(--brand-hover);
+}
+
+.brands-cta:active {
+  transform: scale(0.97);
+}
+
+.brands-cta--desktop {
+  height: 44px;
+  padding: 0 20px;
+}
+
+.brands-cta--mobile {
+  display: none;
+  width: 100%;
+  height: 52px;
+  margin-top: 14px;
+  border-radius: 14px;
+  font-size: 15px;
+}
+
+.brands-scroll {
+  overflow-x: auto;
+}
+
+.brands-wrap {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.brand-card {
+  display: grid;
+  place-items: center;
+  height: 132px;
+  padding: 18px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border);
+  background: #fff;
+  transition:
+    border-color 0.15s ease,
+    transform 0.12s ease;
+}
+
+.brand-card:hover {
+  border-color: var(--color-blue-200);
+  transform: translateY(-2px);
+}
+
+.brand-card__logo {
+  max-width: 100%;
+  max-height: 64px;
+  object-fit: contain;
+  display: block;
+}
+
+.brand-card__fallback {
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--foreground);
+  text-align: center;
+}
+
+:global(.dark) .brand-card {
+  background: var(--card);
+}
+
+@media (max-width: 1023px) {
+  .brands-cta--desktop {
+    display: none;
+  }
+
+  .brands-cta--mobile {
+    display: inline-flex;
+  }
+
+  /* Edge-bleed: отступ строго из --page-gutter (см. assets/css/tailwind.css),
+     иначе рельс не совпадает с контейнером секции. */
+  .brands-scroll {
+    margin-inline: calc(-1 * var(--page-gutter));
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .brands-wrap {
+    grid-auto-flow: column;
+    grid-template-columns: none;
+    grid-template-rows: repeat(3, 88px);
+    grid-auto-columns: 128px;
+    gap: 12px;
+    width: max-content;
+    padding-inline: var(--page-gutter);
+  }
+
+  .brand-card {
+    height: 88px;
+    padding: 12px;
+  }
+
+  .brand-card__logo {
+    max-height: 44px;
+  }
+}
+</style>

--- a/components/home/CategoryChips.vue
+++ b/components/home/CategoryChips.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+/**
+ * Лента быстрых чипов над товарами (Homepage.dc.html: секция chips + Chips.dc.html).
+ *
+ * На главной чипы — это ССЫЛКИ в каталог (решение по продукту: клиентская
+ * фильтрация «Хитов» в прототипе стояла в самом верху страницы, далеко от
+ * сетки, и читалась как сломанная). Поэтому активной «пилюли» здесь нет —
+ * просто стилизованные пилюли-ссылки; никакая из них на главной не активна.
+ */
+interface ChipItem {
+  id: string
+  label: string
+  to: string
+  icon?: string | null
+}
+
+defineProps<{ items: ChipItem[] }>()
+</script>
+
+<template>
+  <div class="home-chips hs">
+    <NuxtLink
+      v-for="chip in items"
+      :key="chip.id"
+      :to="chip.to"
+      class="home-chips__item"
+    >
+      <Icon v-if="chip.icon" :name="chip.icon" class="size-4" />
+      {{ chip.label }}
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.home-chips {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+  width: 100%;
+  /* Боковые 4px — только запас под тень крайних чипов, поэтому он гасится
+     таким же отрицательным margin: видимый край первого чипа обязан лечь
+     ровно на gutter страницы, как заголовки секций. */
+  margin-inline: -4px;
+  padding: 8px 4px;
+}
+
+.home-chips__item {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 38px;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(227, 234, 245, 0.8);
+  background: linear-gradient(165deg, #fff, #f3f7fc);
+  box-shadow: 0 2px 8px rgb(15 23 42 / 0.06);
+  color: var(--foreground);
+  font-weight: 600;
+  font-size: 13.5px;
+  white-space: nowrap;
+  text-decoration: none;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.1s ease;
+}
+
+.home-chips__item:hover {
+  border-color: var(--color-blue-200);
+  color: var(--primary);
+}
+
+.home-chips__item:active {
+  transform: scale(0.96);
+}
+
+:global(.dark) .home-chips__item {
+  border-color: var(--border);
+  background: var(--card);
+}
+</style>

--- a/components/home/DealOfTheDayCard.vue
+++ b/components/home/DealOfTheDayCard.vue
@@ -1,0 +1,342 @@
+<script setup lang="ts">
+import type { BaseProduct, FullProduct } from '@/types'
+import { storeToRefs } from 'pinia'
+import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
+import { BUCKET_NAME_PRODUCT } from '@/constants'
+import { useCartStore } from '@/stores/publicStore/cartStore'
+import { useProductsStore } from '@/stores/publicStore/productsStore'
+
+/**
+ * «Товар дня» — стеклянная карточка (Homepage.dc.html: product of the day).
+ *
+ * Сам товар РЕАЛЬНЫЙ (productsStore.fetchFeaturedProducts(1)). Фабрикуется
+ * только дедлайн: обратный отсчёт до конца локальных суток (см. плейсхолдер
+ * DEAL_COUNTDOWN_MODE в constants/homePlaceholders.ts). На сервере отсчёт не
+ * рисуем, чтобы не ловить hydration mismatch по времени.
+ */
+const productsStore = useProductsStore()
+const cartStore = useCartStore()
+const { getVariantUrl } = useSupabaseStorage()
+const { items } = storeToRefs(cartStore)
+
+const product = ref<FullProduct | null>(null)
+
+onMounted(async () => {
+  const featured = await productsStore.fetchFeaturedProducts(1)
+  product.value = featured?.[0] ?? null
+})
+
+const line = computed(() =>
+  product.value?.product_lines?.name
+  ?? product.value?.categories?.name
+  ?? '',
+)
+
+const imageUrl = computed(() => {
+  const raw = product.value?.product_images?.[0]?.image_url
+  if (!raw)
+    return null
+  if (raw.startsWith('http'))
+    return raw
+  return getVariantUrl(BUCKET_NAME_PRODUCT, raw, 'sm') || null
+})
+
+const priceNow = computed(() => product.value?.final_price ?? 0)
+const priceOld = computed(() => {
+  const p = product.value
+  if (!p)
+    return null
+  // price — «старая» цена, final_price — текущая (old_price-колонки нет).
+  return p.price > p.final_price ? p.price : null
+})
+
+function fmt(n: number): string {
+  return n.toLocaleString('ru-KZ')
+}
+
+const qty = computed(() => {
+  const id = product.value?.id
+  if (!id)
+    return 0
+  return items.value.find(i => i.product.id === id)?.quantity ?? 0
+})
+
+function addOne() {
+  if (product.value)
+    cartStore.addItem(product.value, 1)
+}
+
+// --- обратный отсчёт до конца суток ---
+const countdown = ref('')
+let timer: ReturnType<typeof setInterval> | null = null
+
+function tick() {
+  const now = new Date()
+  const end = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    23,
+    59,
+    59,
+    999,
+  )
+  let diff = Math.max(0, Math.floor((end.getTime() - now.getTime()) / 1000))
+  const h = Math.floor(diff / 3600)
+  diff %= 3600
+  const m = Math.floor(diff / 60)
+  const s = diff % 60
+  const pad = (v: number) => String(v).padStart(2, '0')
+  countdown.value = `${pad(h)}:${pad(m)}:${pad(s)}`
+}
+
+onMounted(() => {
+  tick()
+  timer = setInterval(tick, 1000)
+})
+
+onUnmounted(() => {
+  if (timer)
+    clearInterval(timer)
+})
+</script>
+
+<template>
+  <div v-if="product" class="deal">
+    <span class="deal__glow deal__glow--1" />
+    <span class="deal__glow deal__glow--2" />
+    <span class="deal__frost" />
+    <span class="deal__sheen" />
+
+    <div class="deal__head">
+      <span class="deal__tag">
+        <Icon name="lucide:flame" class="size-[18px] text-[color:var(--color-orange-600)]" />
+        Товар дня
+      </span>
+      <span v-if="countdown" class="deal__timer">
+        <Icon name="lucide:clock" class="size-[13px]" />
+        {{ countdown }}
+      </span>
+    </div>
+
+    <NuxtLink :to="`/catalog/products/${product.slug}`" class="deal__body">
+      <span class="deal__img">
+        <img v-if="imageUrl" :src="imageUrl" :alt="product.name" loading="lazy">
+      </span>
+      <div class="deal__info">
+        <span v-if="line" class="deal__line">{{ line }}</span>
+        <b class="deal__name">{{ product.name }}</b>
+        <div class="deal__buy" @click.prevent>
+          <span class="deal__price">
+            <span v-if="priceOld" class="deal__price-old">{{ fmt(priceOld) }} ₸</span>
+            <span class="deal__price-now">{{ fmt(priceNow) }} ₸</span>
+          </span>
+          <ClientOnly>
+            <QuantitySelector
+              v-if="qty > 0"
+              :product="(product as unknown as BaseProduct)"
+              :quantity="qty"
+            />
+            <button
+              v-else
+              type="button"
+              class="deal__add"
+              aria-label="В корзину"
+              @click="addOne"
+            >
+              <Icon name="lucide:plus" class="size-[22px]" />
+            </button>
+          </ClientOnly>
+        </div>
+      </div>
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.deal {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 0.7);
+  box-shadow:
+    0 22px 48px -24px rgb(15 23 42 / 0.45),
+    inset 0 1px 0 rgb(255 255 255 / 0.9),
+    inset 0 -1px 1px rgb(255 255 255 / 0.35);
+  background: linear-gradient(150deg, rgb(255 255 255 / 0.55), rgb(255 255 255 / 0.28));
+}
+
+.deal__glow {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.deal__glow--1 {
+  top: -54px;
+  left: -34px;
+  width: 210px;
+  height: 210px;
+  background: radial-gradient(circle, rgb(255 150 60 / 0.9), transparent 68%);
+  filter: blur(34px);
+}
+
+.deal__glow--2 {
+  bottom: -64px;
+  right: -24px;
+  width: 230px;
+  height: 230px;
+  background: radial-gradient(circle, rgb(70 140 255 / 0.8), transparent 68%);
+  filter: blur(40px);
+}
+
+.deal__frost {
+  position: absolute;
+  inset: 0;
+  background: rgb(255 255 255 / 0.44);
+  backdrop-filter: blur(22px) saturate(1.7);
+  -webkit-backdrop-filter: blur(22px) saturate(1.7);
+  pointer-events: none;
+}
+
+.deal__sheen {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgb(255 255 255 / 0.7) 0%, rgb(255 255 255 / 0) 34%);
+  pointer-events: none;
+}
+
+.deal__head {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 18px;
+  border-bottom: 1px solid rgb(255 255 255 / 0.5);
+}
+
+.deal__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--foreground);
+}
+
+.deal__timer {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgb(220 38 38 / 0.92);
+  color: #fff;
+  border-radius: 999px;
+  padding: 6px 11px;
+  font-weight: 700;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  box-shadow: 0 4px 12px -4px rgb(220 38 38 / 0.6);
+}
+
+.deal__body {
+  position: relative;
+  display: flex;
+  gap: 16px;
+  padding: 18px;
+  flex: 1;
+  text-decoration: none;
+  color: inherit;
+}
+
+.deal__img {
+  flex: 0 0 auto;
+  width: 116px;
+  height: 116px;
+  border-radius: 16px;
+  background: #fff;
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  padding: 6px;
+}
+
+.deal__img img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.deal__info {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-width: 0;
+}
+
+.deal__line {
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--product-line);
+}
+
+.deal__name {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.deal__buy {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.deal__price {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.deal__price-old {
+  font-weight: 500;
+  font-size: 12px;
+  color: var(--price-old);
+  text-decoration: line-through;
+}
+
+.deal__price-now {
+  font-weight: 800;
+  font-size: 20px;
+  color: var(--foreground);
+}
+
+.deal__add {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--primary);
+  cursor: pointer;
+  display: grid;
+  place-content: center;
+  flex: none;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.deal__add:hover {
+  border-color: var(--primary);
+  background: var(--brand-surface);
+}
+</style>

--- a/components/home/Hero.vue
+++ b/components/home/Hero.vue
@@ -1,0 +1,293 @@
+<script setup lang="ts">
+import type { SlideRow } from '@/types'
+import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
+import { BUCKET_NAME_SLIDES } from '@/constants'
+
+/**
+ * Полноэкранный герой главной (Homepage.dc.html: секция HERO).
+ *
+ * Отличие от CommonAppCarousel: тот рисует «подглядывающую» карточку со
+ * стрелками (basis-4/5, aspect-21/9). Здесь — full-bleed кроссфейд с
+ * точечной пагинацией и автоплеем 6с.
+ *
+ * Раскладка через CSS-медиазапросы (а не JS), чтобы SSR сразу отдавал верную
+ * разметку и на телефоне не мелькал десктопный герой:
+ *   • < 1024px — position:fixed за листом контента (лист наезжает сверху);
+ *   • ≥ 1024px — обычный relative-герой, шапка-overlay поверх него.
+ * Порог 1024 совпадает с lg-разделением шапки в layouts/Home.vue.
+ *
+ * Конвейер изображений скопирован из AppCarousel: art-directed <picture>
+ * (мобильный источник < 768px) + LQIP-подложка из blur_placeholder.
+ */
+const props = withDefaults(
+  defineProps<{
+    slides?: SlideRow[] | null
+    isLoading?: boolean
+    error?: Error | null
+    autoplay?: boolean
+  }>(),
+  { autoplay: true },
+)
+
+const { getVariantUrlWide } = useSupabaseStorage()
+
+const AUTOPLAY_MS = 6000
+
+function slideUrl(imageUrl: string | null, size: 'sm' | 'md' | 'lg'): string | null {
+  if (!imageUrl || imageUrl.startsWith('http'))
+    return imageUrl
+  return getVariantUrlWide(BUCKET_NAME_SLIDES, imageUrl, size)
+}
+
+function buildSrcset(imageUrl: string | null): string | undefined {
+  if (!imageUrl || imageUrl.startsWith('http'))
+    return undefined
+  const parts: string[] = []
+  const sm = slideUrl(imageUrl, 'sm')
+  const md = slideUrl(imageUrl, 'md')
+  const lg = slideUrl(imageUrl, 'lg')
+  if (sm)
+    parts.push(`${sm} 640w`)
+  if (md)
+    parts.push(`${md} 1280w`)
+  if (lg)
+    parts.push(`${lg} 1920w`)
+  return parts.length ? parts.join(', ') : undefined
+}
+
+const processed = computed(() => {
+  if (!props.slides || !Array.isArray(props.slides))
+    return []
+  return props.slides.map((slide) => {
+    const desktopUrl = slideUrl(slide.image_url, 'lg')
+    const mobileUrl = slide.image_url_mobile
+      ? slideUrl(slide.image_url_mobile, 'md')
+      : desktopUrl
+    return {
+      id: slide.id,
+      title: slide.title,
+      alt: slide.alt_text || slide.title || 'Слайд',
+      href: slide.cta_link || slide.link_url || '',
+      external: !!(slide.cta_link || slide.link_url || '').startsWith('http'),
+      blur: slide.blur_placeholder,
+      desktopUrl,
+      desktopSrcset: buildSrcset(slide.image_url),
+      mobileUrl,
+      mobileSrcset: buildSrcset(slide.image_url_mobile || slide.image_url),
+    }
+  })
+})
+
+const showSkeleton = computed(
+  () => props.isLoading && processed.value.length === 0,
+)
+
+const active = ref(0)
+const loadedIds = reactive(new Set<string>())
+function onLoaded(id: string) {
+  loadedIds.add(id)
+}
+
+watch(
+  () => processed.value.length,
+  (len) => {
+    if (active.value >= len)
+      active.value = 0
+  },
+)
+
+function goTo(i: number) {
+  active.value = i
+}
+
+// --- автоплей ---
+let timer: ReturnType<typeof setInterval> | null = null
+const paused = ref(false)
+
+function tick() {
+  const len = processed.value.length
+  if (len > 1 && !paused.value)
+    active.value = (active.value + 1) % len
+}
+
+function start() {
+  stop()
+  if (props.autoplay)
+    timer = setInterval(tick, AUTOPLAY_MS)
+}
+
+function stop() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+function onVisibility() {
+  paused.value = document.hidden
+}
+
+onMounted(() => {
+  start()
+  document.addEventListener('visibilitychange', onVisibility)
+})
+
+onUnmounted(() => {
+  stop()
+  document.removeEventListener('visibilitychange', onVisibility)
+})
+</script>
+
+<template>
+  <section
+    class="home-hero"
+    @mouseenter="paused = true"
+    @mouseleave="paused = false"
+  >
+    <!-- скелетон / пустое состояние: просто нейтральный фон героя -->
+    <div v-if="showSkeleton" class="home-hero__skeleton" />
+
+    <template v-else>
+      <component
+        :is="slide.href ? 'a' : 'div'"
+        v-for="(slide, i) in processed"
+        :key="slide.id"
+        :href="slide.href || undefined"
+        :target="slide.external ? '_blank' : undefined"
+        :rel="slide.external ? 'noopener' : undefined"
+        class="home-hero__slide"
+        :style="{
+          opacity: i === active ? 1 : 0,
+          zIndex: i === active ? 2 : 1,
+          pointerEvents: i === active && slide.href ? 'auto' : 'none',
+        }"
+        :aria-hidden="i === active ? undefined : 'true'"
+      >
+        <img
+          v-if="slide.blur && !loadedIds.has(slide.id)"
+          :src="slide.blur"
+          alt=""
+          class="home-hero__lqip"
+        >
+        <picture>
+          <source
+            v-if="slide.mobileSrcset"
+            media="(max-width: 767px)"
+            :srcset="slide.mobileSrcset"
+            sizes="100vw"
+          >
+          <img
+            v-if="slide.desktopUrl"
+            :src="slide.desktopUrl"
+            :srcset="slide.desktopSrcset"
+            sizes="100vw"
+            :alt="slide.alt"
+            class="home-hero__img"
+            :fetchpriority="i === 0 ? 'high' : 'auto'"
+            :loading="i === 0 ? 'eager' : 'lazy'"
+            decoding="async"
+            @load="onLoaded(slide.id)"
+            @error="onLoaded(slide.id)"
+          >
+        </picture>
+      </component>
+
+      <!-- точки -->
+      <div v-if="processed.length > 1" class="home-hero__dots">
+        <button
+          v-for="(slide, i) in processed"
+          :key="`dot-${slide.id}`"
+          type="button"
+          class="home-hero__dot"
+          :class="{ 'home-hero__dot--active': i === active }"
+          :aria-label="`Слайд ${i + 1}`"
+          :aria-current="i === active ? 'true' : undefined"
+          @click="goTo(i)"
+        />
+      </div>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.home-hero {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: min(62vh, 540px);
+  overflow: hidden;
+  background: #dfe7ee;
+  z-index: 0;
+}
+
+.home-hero__skeleton {
+  position: absolute;
+  inset: 0;
+  background: #dfe7ee;
+}
+
+.home-hero__slide {
+  position: absolute;
+  inset: 0;
+  display: block;
+  cursor: pointer;
+  transition: opacity 0.7s ease;
+}
+
+.home-hero__lqip {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(24px);
+  transform: scale(1.1);
+}
+
+.home-hero__img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.home-hero__dots {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 30px;
+  z-index: 6;
+  display: flex;
+  justify-content: center;
+  gap: 7px;
+}
+
+.home-hero__dot {
+  width: 9px;
+  height: 9px;
+  padding: 0;
+  border: none;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.home-hero__dot--active {
+  width: 26px;
+  background: #fff;
+}
+
+@media (min-width: 1024px) {
+  .home-hero {
+    position: relative;
+    height: clamp(560px, 80vh, 760px);
+  }
+
+  .home-hero__dots {
+    bottom: clamp(20px, 3vw, 34px);
+  }
+}
+</style>

--- a/components/home/LoyaltyBanner.vue
+++ b/components/home/LoyaltyBanner.vue
@@ -1,0 +1,371 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useProfileStore } from '@/stores/core/profileStore'
+import { useAuthStore } from '@/stores/core/useAuthStore'
+import { useModalStore } from '@/stores/modal/useModalStore'
+
+/**
+ * Баннер лояльности + стеклянная бонусная карта (Homepage.dc.html: loyalty banner).
+ *
+ * Ветку «войти / показать баланс» держим на authStore.isLoggedIn (=!!user),
+ * а не на profileStore.isLoggedIn (=!!user && !!profile) — иначе кнопка мигает,
+ * пока догружается профиль.
+ */
+const CASHBACK_MAX = 10 // % — в дизайне захардкожено «до 10%»
+
+const authStore = useAuthStore()
+const profileStore = useProfileStore()
+const modalStore = useModalStore()
+
+const { isLoggedIn, user } = storeToRefs(authStore)
+const { bonusBalance } = storeToRefs(profileStore)
+
+onMounted(() => {
+  if (user.value && !profileStore.profile)
+    profileStore.loadProfile()
+})
+
+const bonusLabel = computed(() =>
+  isLoggedIn.value ? (bonusBalance.value ?? 0).toLocaleString('ru-KZ') : '0',
+)
+
+const benefits = [
+  { icon: 'lucide:percent', text: `Кешбэк до ${CASHBACK_MAX}%` },
+  { icon: 'lucide:gift', text: 'Бонусы за отзывы' },
+  { icon: 'lucide:calendar-check', text: 'Подарок в день рождения' },
+]
+
+function onLogin() {
+  modalStore.openLoginModal()
+}
+</script>
+
+<template>
+  <div class="loyalty">
+    <span class="loyalty__blob loyalty__blob--1" />
+    <span class="loyalty__blob loyalty__blob--2" />
+
+    <div class="loyalty__body">
+      <span class="loyalty__badge">
+        <Icon name="lucide:gift" class="size-3.5" />
+        Бонусная программа
+      </span>
+      <h3 class="loyalty__title">
+        Кешбэк до {{ CASHBACK_MAX }}% бонусами<br>с каждой покупки
+      </h3>
+      <div class="loyalty__pills">
+        <span v-for="b in benefits" :key="b.text" class="loyalty__pill">
+          <Icon :name="b.icon" class="size-3.5" />
+          {{ b.text }}
+        </span>
+      </div>
+      <div class="loyalty__actions">
+        <button v-if="!isLoggedIn" type="button" class="loyalty__btn loyalty__btn--primary" @click="onLogin">
+          <Icon name="lucide:log-in" class="size-[17px]" />
+          Войти и копить
+        </button>
+        <NuxtLink to="/profile/bonuses" class="loyalty__btn loyalty__btn--ghost">
+          <Icon name="lucide:info" class="size-[17px]" />
+          Правила
+        </NuxtLink>
+      </div>
+    </div>
+
+    <!-- стеклянная бонусная карта -->
+    <div class="loyalty__card-wrap">
+      <div class="loyalty__card">
+        <span class="loyalty__card-sheen" />
+        <span class="loyalty__card-glow" />
+        <div class="loyalty__card-top">
+          <span class="loyalty__wordmark">
+            <svg viewBox="11 0 64 78" width="17" height="21" aria-label="Юла">
+              <g transform="translate(2 0)"><g transform="rotate(-9 42 72)">
+                <rect x="37.5" y="4" width="9" height="13" rx="4.5" fill="#fff" />
+                <rect x="34" y="15.5" width="16" height="5.5" rx="2.75" fill="rgba(255,255,255,.65)" />
+                <path d="M16 36 C16 22.5 68 22.5 68 36 L68 36.5 C68 40.6 64.6 44 60.5 44 L23.5 44 C19.4 44 16 40.6 16 36.5 Z" fill="#fff" />
+                <rect x="20" y="46.5" width="44" height="6" rx="3" fill="#ffd34d" />
+                <path d="M23 55 L61 55 C57.5 61.5 50 64 45 70 A3.8 3.8 0 0 1 39 70 C34 64 26.5 61.5 23 55 Z" fill="#ff8ac2" />
+              </g></g>
+            </svg>
+            Ухтышка
+          </span>
+          <span class="loyalty__card-chip">до {{ CASHBACK_MAX }}%</span>
+        </div>
+        <div class="loyalty__card-balance">
+          <div class="loyalty__card-label">
+            Бонусный счёт
+          </div>
+          <div class="loyalty__card-amount">
+            <ClientOnly>
+              <span class="loyalty__card-num">{{ bonusLabel }}</span>
+              <template #fallback>
+                <span class="loyalty__card-num">0</span>
+              </template>
+            </ClientOnly>
+            <span class="loyalty__card-unit">бонусов</span>
+          </div>
+          <ClientOnly>
+            <div v-if="isLoggedIn" class="loyalty__card-rate">
+              1 БОНУС = 1 ₸
+            </div>
+            <div v-else class="loyalty__card-locked">
+              <Icon name="lucide:lock" class="size-3" />
+              Войдите, чтобы копить
+            </div>
+          </ClientOnly>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.loyalty {
+  position: relative;
+  overflow: hidden;
+  border-radius: 24px;
+  background: linear-gradient(120deg, #0f52d9 0%, #2b7fff 52%, #5aa0ff 100%);
+  color: #fff;
+  padding: clamp(26px, 3vw, 44px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(24px, 3vw, 44px);
+  flex-wrap: wrap;
+  box-shadow: 0 20px 46px -20px rgb(43 127 255 / 0.7);
+}
+
+.loyalty__blob {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.loyalty__blob--1 {
+  top: -90px;
+  left: -40px;
+  width: 260px;
+  height: 260px;
+  background: rgb(255 255 255 / 0.1);
+}
+
+.loyalty__blob--2 {
+  bottom: -120px;
+  right: 34%;
+  width: 240px;
+  height: 240px;
+  background: rgb(255 255 255 / 0.07);
+}
+
+.loyalty__body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  min-width: 260px;
+  flex: 1 1 340px;
+}
+
+.loyalty__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border-radius: 999px;
+  padding: 7px 15px;
+  font-weight: 700;
+  font-size: 12.5px;
+  background: rgb(255 255 255 / 0.16);
+  border: 1px solid rgb(255 255 255 / 0.32);
+  backdrop-filter: blur(6px);
+}
+
+.loyalty__title {
+  margin: 0;
+  font-weight: 800;
+  font-size: clamp(26px, 3vw, 42px);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+}
+
+.loyalty__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.loyalty__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-weight: 600;
+  font-size: 13px;
+  background: rgb(255 255 255 / 0.14);
+  border: 1px solid rgb(255 255 255 / 0.2);
+}
+
+.loyalty__actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.loyalty__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  height: 48px;
+  border-radius: 14px;
+  font-weight: 700;
+  font-size: 15px;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    transform 0.1s ease,
+    background 0.15s ease;
+}
+
+.loyalty__btn--primary {
+  padding: 0 24px;
+  border: none;
+  background: #fff;
+  color: var(--primary);
+  box-shadow: 0 8px 20px -8px rgb(0 0 0 / 0.45);
+}
+
+.loyalty__btn--primary:active {
+  transform: scale(0.97);
+}
+
+.loyalty__btn--ghost {
+  padding: 0 20px;
+  border: 1px solid rgb(255 255 255 / 0.55);
+  background: rgb(255 255 255 / 0.1);
+  color: #fff;
+  backdrop-filter: blur(6px);
+}
+
+.loyalty__btn--ghost:hover {
+  background: rgb(255 255 255 / 0.22);
+}
+
+.loyalty__card-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.loyalty__card {
+  position: relative;
+  width: clamp(260px, 26vw, 320px);
+  aspect-ratio: 1.6 / 1;
+  border-radius: 22px;
+  background: linear-gradient(140deg, #1657d6 0%, #3b8bff 100%);
+  box-shadow: 0 26px 60px -16px rgb(0 10 40 / 0.6);
+  transform: rotate(-4deg);
+  overflow: hidden;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.loyalty__card-sheen {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(125deg, rgb(255 255 255 / 0.4) 0%, rgb(255 255 255 / 0) 42%);
+  pointer-events: none;
+}
+
+.loyalty__card-glow {
+  position: absolute;
+  right: -40px;
+  top: -40px;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgb(255 255 255 / 0.28), transparent 65%);
+  pointer-events: none;
+}
+
+.loyalty__card-top {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.loyalty__wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 15px;
+  color: #fff;
+}
+
+.loyalty__card-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 11px;
+  font-weight: 800;
+  font-size: 12px;
+  color: #1657d6;
+  background: rgb(255 255 255 / 0.95);
+}
+
+.loyalty__card-balance {
+  position: relative;
+}
+
+.loyalty__card-label {
+  font-weight: 500;
+  font-size: 12px;
+  color: rgb(255 255 255 / 0.75);
+  margin-bottom: 2px;
+}
+
+.loyalty__card-amount {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.loyalty__card-num {
+  font-weight: 800;
+  font-size: 32px;
+  letter-spacing: -0.02em;
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+}
+
+.loyalty__card-unit {
+  font-weight: 600;
+  font-size: 14px;
+  color: rgb(255 255 255 / 0.85);
+}
+
+.loyalty__card-rate {
+  font-weight: 500;
+  font-size: 11.5px;
+  color: rgb(255 255 255 / 0.7);
+  margin-top: 8px;
+  letter-spacing: 0.04em;
+}
+
+.loyalty__card-locked {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 11.5px;
+  color: rgb(255 255 255 / 0.92);
+  margin-top: 8px;
+}
+</style>

--- a/components/home/PopularCategories.vue
+++ b/components/home/PopularCategories.vue
@@ -1,272 +1,455 @@
 <script setup lang="ts">
-import { useQuery } from '@tanstack/vue-query'
-import { onMounted, ref } from 'vue'
+import type { CategoryMenuItem } from '@/types'
 import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
+import { useIsMobile } from '@/composables/useIsMobile'
 import { BUCKET_NAME_CATEGORY } from '@/constants'
-import { usePopularCategoriesStore } from '@/stores/publicStore/popularCategoriesStore'
+import {
+  CATEGORY_TILE_TINT_FALLBACK,
+  CATEGORY_TILE_TINTS,
+} from '@/constants/homePlaceholders'
+import { sectionSpacingVariants } from '@/lib/variants'
+import { useCategoriesStore } from '@/stores/publicStore/categoriesStore'
 
-const popularCategoriesStore = usePopularCategoriesStore()
+/**
+ * «Популярные категории» (Homepage.dc.html: секция categories).
+ *
+ * Табы = синтетический «Всё» + корневые категории из categoriesStore.menuTree.
+ * Раскладка:
+ *   • bento — только на десктопе и только на табе «Всё» (2 больших + 8 малых);
+ *   • focus-grid — во всех остальных случаях (мобилка всегда, либо конкретный
+ *     корневой таб на десктопе): плитки = подкатегории выбранного корня.
+ * Подпись-счётчик у больших плиток = число дочерних категорий
+ * (в прототипе cnt:10/12 совпадали с длиной CATSUB — это дети, не товары).
+ */
+const categoriesStore = useCategoriesStore()
 const { getVariantUrl } = useSupabaseStorage()
+const isMobile = useIsMobile(1023)
 
-// 🔥 TanStack Query - популярные категории с автоматическим кешированием
-const { data: popularCategories, isLoading, isFetching } = useQuery({
-  queryKey: ['home-popular-categories'],
-  queryFn: async () => {
-    await popularCategoriesStore.fetchPopularCategories()
-    return popularCategoriesStore.popularCategories
-  },
-  staleTime: 5 * 60 * 1000,
-  gcTime: 10 * 60 * 1000,
-})
-
-const categories = computed(() => popularCategories.value ?? null)
-
-// Показываем skeleton только при загрузке без данных
-const showSkeleton = computed(() => (isLoading.value || isFetching.value) && !categories.value)
-
-function getCategoryImageUrl(imageUrl: string | null, size: 'sm' | 'md' = 'sm') {
-  if (!imageUrl)
-    return '/images/placeholder.svg'
-
-  return getVariantUrl(BUCKET_NAME_CATEGORY, imageUrl, size)
-    || '/images/placeholder.svg'
-}
-
-function getCategoryImageVariants(imageUrl: string | null) {
-  if (!imageUrl) {
-    return { sm: null, md: null, lg: null }
-  }
-  return {
-    sm: getVariantUrl(BUCKET_NAME_CATEGORY, imageUrl, 'sm'),
-    md: getVariantUrl(BUCKET_NAME_CATEGORY, imageUrl, 'md'),
-    lg: getVariantUrl(BUCKET_NAME_CATEGORY, imageUrl, 'lg'),
-  }
-}
-
-// Touch scroll functionality
-const scrollContainer = ref<HTMLElement | null>(null)
-let isDown = false
-let startX = 0
-let scrollLeft = 0
-
+// menuTree наполняется на SSR через useAsyncData('home-ssr-critical') в index.vue;
+// подстраховка на клиенте, если стор пуст.
 onMounted(() => {
-  // Touch scroll setup
-  const container = scrollContainer.value
-  if (!container)
-    return
-
-  container.addEventListener('mousedown', (e) => {
-    isDown = true
-    container.style.cursor = 'grabbing'
-    startX = e.pageX - container.offsetLeft
-    scrollLeft = container.scrollLeft
-  })
-
-  container.addEventListener('mouseleave', () => {
-    isDown = false
-    container.style.cursor = 'grab'
-  })
-
-  container.addEventListener('mouseup', () => {
-    isDown = false
-    container.style.cursor = 'grab'
-  })
-
-  container.addEventListener('mousemove', (e) => {
-    if (!isDown)
-      return
-    e.preventDefault()
-    const x = e.pageX - container.offsetLeft
-    const walk = (x - startX) * 2
-    container.scrollLeft = scrollLeft - walk
-  })
+  if (!categoriesStore.menuTree.length)
+    categoriesStore.fetchCategoryData()
 })
+
+const roots = computed<CategoryMenuItem[]>(() =>
+  (categoriesStore.menuTree ?? []).filter(c => c.display_in_menu !== false),
+)
+
+const showSkeleton = computed(() => roots.value.length === 0)
+
+// --- табы ---
+const activeTab = ref('all')
+const MAX_ROOT_TABS = 6
+
+const tabs = computed(() => {
+  const rootTabs = roots.value.slice(0, MAX_ROOT_TABS).map(r => ({
+    key: r.slug,
+    name: r.name,
+    icon: r.icon_name || 'lucide:shapes',
+  }))
+  return [
+    { key: 'all', name: 'Всё', icon: 'lucide:sparkles' },
+    ...rootTabs,
+  ]
+})
+
+const isAllTab = computed(() => activeTab.value === 'all')
+const showBento = computed(() => isAllTab.value && !isMobile.value)
+
+function tintFor(index: number): string {
+  return CATEGORY_TILE_TINTS[index % CATEGORY_TILE_TINTS.length]
+    ?? CATEGORY_TILE_TINT_FALLBACK
+}
+
+function imageOf(item: CategoryMenuItem): string | null {
+  if (!item.image_url)
+    return null
+  return getVariantUrl(BUCKET_NAME_CATEGORY, item.image_url, 'md') || null
+}
+
+function hrefOf(item: CategoryMenuItem): string {
+  return item.href || `/catalog/${item.slug}`
+}
+
+function plural(n: number, forms: [string, string, string]): string {
+  const mod10 = n % 10
+  const mod100 = n % 100
+  if (mod10 === 1 && mod100 !== 11)
+    return forms[0]
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20))
+    return forms[1]
+  return forms[2]
+}
+
+interface Tile {
+  id: string
+  name: string
+  href: string
+  image: string | null
+  blur: string | null
+  tint: string
+  countLabel?: string
+}
+
+function toTile(item: CategoryMenuItem, tintIndex: number, withCount = false): Tile {
+  const childCount = item.children?.length ?? 0
+  return {
+    id: item.id,
+    name: item.name,
+    href: hrefOf(item),
+    image: imageOf(item),
+    blur: item.blur_placeholder,
+    tint: tintFor(tintIndex),
+    countLabel: withCount
+      ? (childCount > 0
+          ? `${childCount} ${plural(childCount, ['категория', 'категории', 'категорий'])}`
+          : 'Смотреть')
+      : undefined,
+  }
+}
+
+// Большие плитки бенто — первые два корня.
+const bentoBig = computed<Tile[]>(() =>
+  roots.value.slice(0, 2).map((r, i) => toTile(r, i, true)),
+)
+
+// Малые плитки бенто — 8 штук: сперва остальные корни, затем дети ранних корней.
+const bentoSmall = computed<Tile[]>(() => {
+  const pool: Array<{ item: CategoryMenuItem, tint: number }> = []
+  roots.value.slice(2).forEach((r, i) => pool.push({ item: r, tint: i + 2 }))
+  roots.value.forEach((r, ri) =>
+    (r.children ?? []).forEach(ch => pool.push({ item: ch, tint: ri })),
+  )
+  const seen = new Set<string>()
+  const out: Tile[] = []
+  for (const { item, tint } of pool) {
+    if (seen.has(item.id))
+      continue
+    seen.add(item.id)
+    out.push(toTile(item, tint))
+    if (out.length >= 8)
+      break
+  }
+  return out
+})
+
+// Плитки focus-grid.
+const focusTiles = computed<Tile[]>(() => {
+  if (isAllTab.value)
+    return [...bentoBig.value, ...bentoSmall.value]
+  const rootIndex = roots.value.findIndex(r => r.slug === activeTab.value)
+  const root = roots.value[rootIndex]
+  if (!root)
+    return []
+  return (root.children ?? []).map(ch => toTile(ch, rootIndex))
+})
+
+const seeAllHref = '/catalog/all'
 </script>
 
 <template>
-  <div class="py-8 md:py-12">
-    <h2 class="text-xl md:text-3xl font-bold tracking-tight text-start mb-8">
-      Популярные категории
-    </h2>
+  <section :class="sectionSpacingVariants({ size: 'xs' })">
+    <div class="flex items-baseline justify-between gap-3 mb-4">
+      <h2 class="m-0 font-bold tracking-tight text-[clamp(22px,3vw,32px)]">
+        Популярные категории
+      </h2>
+      <NuxtLink
+        :to="seeAllHref"
+        class="inline-flex items-center gap-1.5 text-primary font-semibold text-sm whitespace-nowrap hover:underline"
+      >
+        Все категории
+        <Icon name="lucide:arrow-right" class="size-4" />
+      </NuxtLink>
+    </div>
 
-    <ClientOnly>
-      <div v-if="showSkeleton">
-        <div class="md:hidden overflow-x-auto hide-scrollbar">
-          <div class="flex gap-3 px-4 pb-2">
-            <div v-for="i in 6" :key="i">
-              <Skeleton class="h-20 w-40 rounded-2xl flex-shrink-0" />
-            </div>
-          </div>
-        </div>
+    <!-- skeleton -->
+    <div v-if="showSkeleton" class="cats-skeleton">
+      <div v-for="i in 8" :key="i" class="cats-skeleton__tile" />
+    </div>
 
-        <div class="hidden md:grid grid-cols-2 lg:grid-cols-4 gap-4 max-w-7xl mx-auto px-4">
-          <div v-for="i in 8" :key="i">
-            <Skeleton class="h-48 rounded-3xl" />
-          </div>
-        </div>
-      </div>
-
-      <div v-else-if="categories && categories.length > 0">
-        <div
-          ref="scrollContainer"
-          class="md:hidden overflow-x-auto hide-scrollbar cursor-grab active:cursor-grabbing scroll-smooth"
-          style="-webkit-overflow-scrolling: touch;"
+    <template v-else>
+      <!-- табы категорий -->
+      <div class="cats-tabs hs">
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          type="button"
+          class="cats-tab"
+          :class="{ 'cats-tab--active': tab.key === activeTab }"
+          @click="activeTab = tab.key"
         >
-          <div class="flex flex-col gap-3 px-4 pb-2 h-[192px]">
-            <div class="flex gap-3 flex-1">
-              <NuxtLink
-                v-for="category in categories.filter((_, i) => i % 2 === 0)"
-                :key="category.id"
-                :to="category.href"
-                class="group flex-shrink-0"
-              >
-                <div
-                  class="
-                      flex items-center gap-3 h-[88px] w-52 px-3 py-3
-                      bg-white
-                      border border-gray-200 rounded-2xl
-                      shadow-sm
-                      transition-all duration-300
-                      hover:shadow-md hover:border-gray-300
-                      cursor-pointer
-                      relative overflow-hidden
-                    "
-                >
-                  <div class="absolute inset-0 bg-gradient-to-r from-primary/0 to-primary/0 group-hover:from-primary/5 group-hover:to-primary/10 transition-all duration-300" />
-                  <ProgressiveImage
-                    :src="getCategoryImageUrl(category.image_url || null)"
-                    :blur-data-url="category.blur_placeholder || null"
-                    :alt="category.name"
-                    object-fit="contain"
-                    :placeholder-type="category.blur_placeholder ? 'lqip' : 'shimmer'"
-                    class="w-14 h-14 flex-shrink-0 rounded-xl"
-                  />
-                  <span class="font-semibold text-sm text-gray-900 relative z-10 group-hover:text-gray-900 transition-colors leading-snug flex-1 break-words">
-                    {{ category.name }}
-                  </span>
-                </div>
-              </NuxtLink>
-            </div>
-            <div class="flex gap-3 flex-1">
-              <NuxtLink
-                v-for="category in categories.filter((_, i) => i % 2 === 1)"
-                :key="category.id"
-                :to="category.href"
-                class="group flex-shrink-0"
-              >
-                <div
-                  class="
-                      flex items-center gap-3 h-[88px] w-52 px-3 py-3
-                      bg-white
-                      border border-gray-200 rounded-2xl
-                      shadow-sm
-                      transition-all duration-300
-                      hover:shadow-md hover:border-gray-300
-                      cursor-pointer
-                      relative overflow-hidden
-                    "
-                >
-                  <div class="absolute inset-0 bg-gradient-to-r from-primary/0 to-primary/0 group-hover:from-primary/5 group-hover:to-primary/10 transition-all duration-300" />
-                  <ProgressiveImage
-                    :src="getCategoryImageUrl(category.image_url || null)"
-                    :blur-data-url="category.blur_placeholder || null"
-                    :alt="category.name"
-                    object-fit="contain"
-                    :placeholder-type="category.blur_placeholder ? 'lqip' : 'shimmer'"
-                    class="w-14 h-14 flex-shrink-0 rounded-xl"
-                  />
-                  <span class="font-semibold text-sm text-gray-900 relative z-10 group-hover:text-gray-900 transition-colors leading-snug flex-1 break-words">
-                    {{ category.name }}
-                  </span>
-                </div>
-              </NuxtLink>
-            </div>
-          </div>
-        </div>
+          <Icon :name="tab.icon" class="size-4" />
+          {{ tab.name }}
+        </button>
+      </div>
 
-        <div class="hidden md:block">
-          <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
-            <NuxtLink
-              v-for="category in categories"
-              :key="category.id"
-              :to="category.href"
-              class="group"
-            >
-              <div
-                class="
-                  relative h-48 rounded-3xl overflow-hidden
-                  bg-gradient-to-br from-gray-50 to-gray-100
-                  border border-gray-200
-                  transition-all duration-300
-                  hover:shadow-xl hover:border-gray-300 hover:-translate-y-1
-                  cursor-pointer
-                "
-              >
-                <div class="absolute inset-0 bg-gradient-to-br from-primary/0 to-primary/0 group-hover:from-primary/5 group-hover:to-primary/10 transition-all duration-300" />
+      <!-- BENTO (десктоп, таб «Всё») -->
+      <div v-if="showBento" class="cats-bento">
+        <NuxtLink
+          v-for="tile in bentoBig"
+          :key="tile.id"
+          :to="tile.href"
+          class="cats-tile cats-tile--big"
+          :style="{ background: tile.tint }"
+        >
+          <span class="cats-tile__title cats-tile__title--big">{{ tile.name }}</span>
+          <span class="cats-tile__count">
+            {{ tile.countLabel }}
+            <Icon name="lucide:arrow-right" class="size-4" />
+          </span>
+          <span class="cats-tile__img cats-tile__img--big">
+            <img v-if="tile.image" :src="tile.image" :alt="tile.name" loading="lazy">
+          </span>
+        </NuxtLink>
 
-                <div class="absolute inset-0 flex flex-col p-4">
-                  <div class="flex-shrink-0 pr-16">
-                    <h3 class="text-base font-bold text-gray-900 leading-tight break-words">
-                      {{ category.name }}
-                    </h3>
-                  </div>
-
-                  <div class="flex-1 min-h-0" />
-
-                  <div class="flex-shrink-0 flex items-end justify-between">
-                    <div class="w-10 h-10 rounded-full bg-white shadow-sm flex items-center justify-center group-hover:bg-primary group-hover:text-white transition-all duration-300">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                      </svg>
-                    </div>
-
-                    <ProgressiveImage
-                      :src="getCategoryImageUrl(category.image_url || null, 'md')"
-                      :blur-data-url="category.blur_placeholder || null"
-                      :alt="category.name"
-                      object-fit="contain"
-                      :placeholder-type="category.blur_placeholder ? 'lqip' : 'shimmer'"
-                      class="absolute bottom-0 right-0 w-24 h-24"
-                    />
-                  </div>
-                </div>
-              </div>
-            </NuxtLink>
-          </div>
+        <div class="cats-bento__small">
+          <NuxtLink
+            v-for="tile in bentoSmall"
+            :key="tile.id"
+            :to="tile.href"
+            class="cats-tile cats-tile--small"
+            :style="{ background: tile.tint }"
+          >
+            <span class="cats-tile__title">{{ tile.name }}</span>
+            <span class="cats-tile__img cats-tile__img--small">
+              <img v-if="tile.image" :src="tile.image" :alt="tile.name" loading="lazy">
+            </span>
+          </NuxtLink>
         </div>
       </div>
 
-      <div v-else class="text-center text-muted-foreground py-10">
-        <p>Популярные категории скоро появятся здесь.</p>
-      </div>
-
-      <template #fallback>
-        <div>
-          <div class="md:hidden overflow-x-auto hide-scrollbar">
-            <div class="flex gap-3 px-4 pb-2">
-              <div v-for="i in 6" :key="i">
-                <Skeleton class="h-20 w-40 rounded-2xl flex-shrink-0" />
-              </div>
-            </div>
-          </div>
-
-          <div class="hidden md:grid grid-cols-2 lg:grid-cols-4 gap-4 max-w-7xl mx-auto px-4">
-            <div v-for="i in 8" :key="i">
-              <Skeleton class="h-48 rounded-3xl" />
-            </div>
-          </div>
+      <!-- FOCUS GRID (мобилка / конкретный таб) -->
+      <div v-else class="cats-focus-scroll">
+        <div class="cats-focus-grid">
+          <NuxtLink
+            v-for="tile in focusTiles"
+            :key="tile.id"
+            :to="tile.href"
+            class="cats-tile cats-tile--small"
+            :style="{ background: tile.tint }"
+          >
+            <span class="cats-tile__title">{{ tile.name }}</span>
+            <span class="cats-tile__img cats-tile__img--small">
+              <img v-if="tile.image" :src="tile.image" :alt="tile.name" loading="lazy">
+            </span>
+          </NuxtLink>
         </div>
-      </template>
-    </ClientOnly>
-  </div>
+      </div>
+    </template>
+  </section>
 </template>
 
 <style scoped>
-.hide-scrollbar {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+.cats-tabs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 6px;
+  margin-bottom: 18px;
 }
-.hide-scrollbar::-webkit-scrollbar {
-  display: none;
+
+.cats-tab {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 38px;
+  padding: 0 15px;
+  border: none;
+  border-radius: 999px;
+  background: var(--muted);
+  color: var(--foreground);
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.cats-tab--active {
+  background: var(--primary);
+  color: #fff;
+}
+
+/* --- bento --- */
+.cats-bento {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.15fr) minmax(0, 2.7fr);
+  gap: 14px;
+  height: 404px;
+}
+
+.cats-bento__small {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: 1fr 1fr;
+  gap: 14px;
+  height: 100%;
+}
+
+/* --- focus grid --- */
+.cats-focus-scroll {
+  overflow: visible;
+}
+
+.cats-focus-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  grid-auto-rows: 190px;
+  gap: 14px;
+}
+
+/* --- tiles --- */
+.cats-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+  height: 100%;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  overflow: hidden;
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.cats-tile--big {
+  min-height: 180px;
+  border-radius: 22px;
+  padding: 24px 22px 0;
+}
+
+.cats-tile--small {
+  min-height: 150px;
+  border-radius: 18px;
+  padding: 15px 10px 0;
+}
+
+.cats-tile--big:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+}
+
+.cats-tile--small:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-md);
+}
+
+.cats-tile__title {
+  position: relative;
+  z-index: 2;
+  display: block;
+  max-width: 100%;
+  padding-right: 6px;
+  color: var(--foreground);
+  font-weight: 700;
+  font-size: clamp(11px, 1.1vw, 14px);
+  line-height: 1.2;
+  text-wrap: balance;
+}
+
+.cats-tile__title--big {
+  max-width: 72%;
+  font-weight: 800;
+  font-size: clamp(22px, 1.9vw, 30px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+}
+
+.cats-tile__count {
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 11px;
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 13.5px;
+}
+
+.cats-tile__img {
+  position: absolute;
+  z-index: 1;
+}
+
+.cats-tile__img img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: right bottom;
+  display: block;
+}
+
+.cats-tile__img--big {
+  right: 0;
+  bottom: 0;
+  width: 82%;
+  height: 62%;
+}
+
+.cats-tile__img--small {
+  right: 2px;
+  bottom: 2px;
+  width: 76%;
+  height: 62%;
+}
+
+/* --- skeleton --- */
+.cats-skeleton {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 14px;
+}
+
+.cats-skeleton__tile {
+  height: 190px;
+  border-radius: 18px;
+  background: var(--muted);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Мобильный focus-grid — двухрядный горизонтальный скролл (< lg). */
+@media (max-width: 1023px) {
+  /* Edge-bleed: отступ строго из --page-gutter (см. assets/css/tailwind.css),
+     иначе рельс не совпадает с контейнером секции. */
+  .cats-focus-scroll {
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    margin-inline: calc(-1 * var(--page-gutter));
+    scrollbar-width: none;
+  }
+
+  .cats-focus-scroll::-webkit-scrollbar {
+    display: none;
+  }
+
+  .cats-focus-grid {
+    grid-auto-flow: column;
+    grid-template-columns: none;
+    grid-template-rows: repeat(2, 150px);
+    grid-auto-columns: 150px;
+    grid-auto-rows: auto;
+    gap: 12px;
+    width: max-content;
+    padding-inline: var(--page-gutter);
+    padding-bottom: 6px;
+  }
 }
 </style>

--- a/components/home/ProductsCarousel.vue
+++ b/components/home/ProductsCarousel.vue
@@ -1,30 +1,30 @@
 <script setup lang="ts">
 import type { BaseProduct } from '@/types'
-import { carouselContainerVariants } from '@/lib/variants'
+import { sectionSpacingVariants } from '@/lib/variants'
 
+/**
+ * Секция «лента товаров» на главной.
+ *
+ * Ширину себе НЕ задаёт: и скелетон, и ProductCarousel самодостаточны
+ * (заголовок в контейнере 'always', лента — контейнер 'desktop' + отступ
+ * внутри самой ленты).
+ * Оборачивать этот компонент снаружи в контейнер нельзя — будет двойной padding.
+ */
 const props = defineProps<{
   products: BaseProduct[] | null
   isLoading: boolean
   title: string
   seeAllLink: string
 }>()
-
-// Используем единый стиль контейнеров
-const containerClass = carouselContainerVariants({ contained: 'desktop' })
 </script>
 
 <template>
-  <section class="py-4">
-    <!-- 1. Если идет загрузка, показываем скелетон -->
-    <div v-if="isLoading" :class="containerClass">
-      <h2 class="text-xl md:text-3xl font-bold tracking-tight mb-8">
-        {{ props.title }}
-      </h2>
-      <ProductCarouselSkeleton />
-    </div>
+  <!-- 1. Если идет загрузка, показываем скелетон -->
+  <ProductCarouselSectionSkeleton v-if="isLoading" :title="props.title" />
 
-    <!-- 2. Если загрузка завершена И есть товары, показываем карусель -->
-    <ProductCarousel v-else-if="products && products.length > 0" :products="products">
+  <!-- 2. Если загрузка завершена И есть товары, показываем карусель -->
+  <section v-else-if="products && products.length > 0" :class="sectionSpacingVariants({ size: 'xs' })">
+    <ProductCarousel :products="products">
       <template #header>
         <div class="flex justify-between items-center mb-8">
           <h2 class="text-xl md:text-3xl font-bold tracking-tight">
@@ -38,7 +38,7 @@ const containerClass = carouselContainerVariants({ contained: 'desktop' })
         </div>
       </template>
     </ProductCarousel>
-
-    <!-- 3. Если загрузка завершена, но товаров нет, НЕ показываем ничего -->
   </section>
+
+  <!-- 3. Если загрузка завершена, но товаров нет, НЕ показываем ничего -->
 </template>

--- a/components/home/PromoBenefitTiles.vue
+++ b/components/home/PromoBenefitTiles.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import type { Database } from '@/types'
+import {
+  HOME_DELIVERY_TILE,
+  HOME_DISCOUNT_TILE_FALLBACK,
+} from '@/constants/homePlaceholders'
+
+/**
+ * Плитки выгод в блоке «Акции и бонусы» (Homepage.dc.html: benefit tiles).
+ *
+ * Скидочная плитка НЕ хардкодит цифру: тянет максимальный процент из активных
+ * promo_campaigns (таблица публично читаема). Нет активных кампаний → фолбэк
+ * без конкретной цифры. Плитка доставки — из выверенной по оферте константы
+ * (см. comment в constants/homePlaceholders.ts: «1–3 дня», не «1–2»).
+ */
+const supabase = useSupabaseClient<Database>()
+
+const { data: topCampaign } = await useAsyncData(
+  'home-top-discount',
+  async () => {
+    const { data, error } = await supabase
+      .from('promo_campaigns')
+      .select('slug, title, discount_percentage')
+      .eq('is_active', true)
+      .order('discount_percentage', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (error) {
+      console.error('❌ Не удалось загрузить акции:', error)
+      return null
+    }
+    return data
+  },
+  { server: false, lazy: true, default: () => null },
+)
+
+const discountTile = computed(() => {
+  const c = topCampaign.value
+  if (c && c.discount_percentage) {
+    return {
+      id: 'discounts',
+      title: `Скидки до −${c.discount_percentage}%`,
+      subtitle: c.title || 'на хиты недели и распродажу',
+      icon: 'lucide:badge-percent',
+      href: `/promo/${c.slug}`,
+      accent: 'orange' as const,
+    }
+  }
+  return HOME_DISCOUNT_TILE_FALLBACK
+})
+
+const deliveryTile = HOME_DELIVERY_TILE
+</script>
+
+<template>
+  <div class="tiles">
+    <NuxtLink :to="discountTile.href" class="tile tile--orange">
+      <span class="tile__icon tile__icon--orange">
+        <Icon :name="discountTile.icon" class="size-[26px] text-white" />
+      </span>
+      <div class="tile__text">
+        <b class="tile__title tile__title--orange">{{ discountTile.title }}</b>
+        <span class="tile__sub tile__sub--orange">{{ discountTile.subtitle }}</span>
+      </div>
+    </NuxtLink>
+
+    <NuxtLink :to="deliveryTile.href" class="tile tile--blue">
+      <span class="tile__icon tile__icon--blue">
+        <Icon :name="deliveryTile.icon" class="size-[26px] text-white" />
+      </span>
+      <div class="tile__text">
+        <b class="tile__title tile__title--blue">{{ deliveryTile.title }}</b>
+        <span class="tile__sub tile__sub--blue">{{ deliveryTile.subtitle }}</span>
+      </div>
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.tiles {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 1.6vw, 20px);
+}
+
+.tile {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  border-radius: 20px;
+  padding: 22px;
+  text-decoration: none;
+  transition: transform 0.12s ease;
+}
+
+.tile:hover {
+  transform: translateY(-2px);
+}
+
+.tile--orange {
+  background: linear-gradient(140deg, #fff6ec, #ffe6cc);
+  border: 1px solid #ffd9b0;
+}
+
+.tile--blue {
+  background: var(--brand-surface);
+  border: 1px solid var(--color-blue-200);
+}
+
+.tile__icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 15px;
+  display: grid;
+  place-content: center;
+  flex: none;
+}
+
+.tile__icon--orange {
+  background: var(--color-orange-600);
+  box-shadow: 0 8px 18px -8px rgb(234 120 20 / 0.8);
+}
+
+.tile__icon--blue {
+  background: var(--primary);
+  box-shadow: 0 8px 18px -8px rgb(43 127 255 / 0.8);
+}
+
+.tile__title {
+  display: block;
+  font-weight: 800;
+  font-size: 24px;
+  letter-spacing: -0.02em;
+}
+
+.tile__title--orange {
+  color: var(--color-orange-600);
+}
+
+.tile__title--blue {
+  color: var(--primary);
+}
+
+.tile__sub {
+  font-weight: 500;
+  font-size: 13.5px;
+  line-height: 1.4;
+}
+
+.tile__sub--orange {
+  color: #8a5a1f;
+}
+
+.tile__sub--blue {
+  color: var(--muted-foreground);
+}
+</style>

--- a/components/home/StickySearchRow.vue
+++ b/components/home/StickySearchRow.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useHomeStickySearch } from '@/composables/useHomeChrome'
+import { carouselContainerVariants } from '@/lib/variants'
+import { useProfileStore } from '@/stores/core/profileStore'
+import { useAuthStore } from '@/stores/core/useAuthStore'
+import { useModalStore } from '@/stores/modal/useModalStore'
+
+/**
+ * Мобильная липкая строка: поиск + бонусы/вход + уведомления
+ * (Homepage.dc.html: mobile search + bonus row).
+ *
+ * Заменяет удалённую мобильную шапку. Прилипает к верху через нулевой сентинел
+ * (useHomeStickySearch); в момент прилипания подставляется распорка, чтобы лист
+ * не «дёрнулся». Показывается только на мобильном (< lg) — обёртка в index.vue.
+ */
+const authStore = useAuthStore()
+const profileStore = useProfileStore()
+const modalStore = useModalStore()
+
+// Ширина ровно как у секций страницы: фон/блюр тянутся на всю ширину,
+// содержимое живёт в общем контейнере (в т.ч. когда строка прилипла).
+const containerClass = carouselContainerVariants({ contained: 'always' })
+
+const { isLoggedIn, user } = storeToRefs(authStore)
+const { bonusBalance } = storeToRefs(profileStore)
+
+onMounted(() => {
+  if (user.value && !profileStore.profile)
+    profileStore.loadProfile()
+})
+
+const bonusLabel = computed(() =>
+  `${(bonusBalance.value ?? 0).toLocaleString('ru-KZ')} ₸`,
+)
+
+const sentinelEl = ref<HTMLElement | null>(null)
+const searchRowEl = ref<HTMLElement | null>(null)
+const { isSearchStuck, stuckRowHeight } = useHomeStickySearch({
+  sentinelEl,
+  searchRowEl,
+})
+
+const isSearchOpen = ref(false)
+function openSearch() {
+  isSearchOpen.value = true
+}
+function onLogin() {
+  modalStore.openLoginModal()
+}
+</script>
+
+<template>
+  <div>
+    <div ref="sentinelEl" class="h-0" />
+    <div
+      ref="searchRowEl"
+      class="sticky-row"
+      :class="{ 'sticky-row--stuck': isSearchStuck }"
+    >
+      <div :class="containerClass" class="sticky-row__inner">
+        <button type="button" class="sticky-row__search" @click="openSearch">
+          <Icon name="lucide:search" class="size-[22px] text-muted-foreground shrink-0" />
+          <span class="sticky-row__placeholder">Найти товары</span>
+        </button>
+
+        <ClientOnly>
+          <div v-if="isLoggedIn" class="sticky-row__bonus">
+            <Icon name="lucide:coins" class="size-[18px]" />
+            {{ bonusLabel }}
+          </div>
+          <button v-else type="button" class="sticky-row__login" @click="onLogin">
+            <Icon name="lucide:user" class="size-[18px]" />
+            Войти
+          </button>
+        </ClientOnly>
+
+        <ClientOnly>
+          <CommonNotificationBell v-if="isLoggedIn" />
+        </ClientOnly>
+      </div>
+    </div>
+
+    <!-- распорка под fixed-строкой -->
+    <div :style="{ height: isSearchStuck ? `${stuckRowHeight}px` : '0px' }" />
+
+    <SearchDrawer v-model:is-open="isSearchOpen" />
+  </div>
+</template>
+
+<style scoped>
+/* Боковые отступы задаёт контейнер на .sticky-row__inner — здесь только
+   вертикальные, иначе строка разъедется с секциями страницы. */
+.sticky-row {
+  padding: 16px 0 4px;
+  position: relative;
+  z-index: 1;
+}
+
+.sticky-row__inner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sticky-row--stuck {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 10px 0;
+  background: rgb(255 255 255 / 0.86);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  box-shadow: 0 6px 20px rgb(15 23 42 / 0.1);
+}
+
+.sticky-row__search {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 52px;
+  padding: 0 18px;
+  background: var(--muted);
+  border: none;
+  border-radius: 16px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.sticky-row__placeholder {
+  color: var(--muted-foreground);
+  font-weight: 500;
+  font-size: 16px;
+}
+
+.sticky-row__bonus {
+  flex: none;
+  height: 52px;
+  padding: 0 16px;
+  border-radius: 16px;
+  background: var(--bonus-surface);
+  border: 1px solid var(--bonus-border);
+  color: var(--bonus);
+  font-weight: 800;
+  font-size: 15px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sticky-row__login {
+  flex: none;
+  height: 52px;
+  padding: 0 18px;
+  border: none;
+  border-radius: 16px;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: background 0.15s ease;
+}
+
+.sticky-row__login:hover {
+  background: var(--brand-hover);
+}
+
+:global(.dark) .sticky-row--stuck {
+  background: rgb(20 20 20 / 0.86);
+}
+</style>

--- a/composables/useHomeChrome.ts
+++ b/composables/useHomeChrome.ts
@@ -1,0 +1,57 @@
+/**
+ * Прилипание мобильной строки поиска на главной.
+ *
+ * В прототипе (Homepage.dc.html:923-933) над строкой поиска стоит нулевой по
+ * высоте сентинел. Как только он уходит за верхнюю кромку вьюпорта, строка
+ * фиксируется у верха экрана. В момент прилипания снимается реальная высота
+ * строки, и вместо неё подставляется распорка той же высоты — иначе контент
+ * «подпрыгнул» бы на величину строки.
+ *
+ * Состояние прозрачной→стеклянной ШАПКИ здесь НЕ живёт: им владеет
+ * `Header.vue` в режиме `overlay` (шапка десктопная, её порог завязан на
+ * высоту героя). Разводим ответственность, чтобы не считать одно и то же
+ * в двух местах.
+ *
+ * Наблюдатель вешается только на клиенте и снимается автоматически
+ * (`useIntersectionObserver` из @vueuse/core).
+ */
+import type { Ref } from 'vue'
+import { useIntersectionObserver } from '@vueuse/core'
+
+/** Фолбэк высоты липкой строки, пока не удалось замерить (Homepage.dc.html:929). */
+const STICKY_ROW_FALLBACK_HEIGHT = 72
+
+export interface UseHomeStickySearchOptions {
+  /** Нулевой по высоте сентинел прямо над строкой поиска. */
+  sentinelEl: Ref<HTMLElement | null>
+  /** Сама строка поиска — с неё снимается высота для распорки. */
+  searchRowEl: Ref<HTMLElement | null>
+}
+
+export function useHomeStickySearch(options: UseHomeStickySearchOptions) {
+  const { sentinelEl, searchRowEl } = options
+
+  const isSearchStuck = ref(false)
+  const stuckRowHeight = ref(STICKY_ROW_FALLBACK_HEIGHT)
+
+  useIntersectionObserver(
+    sentinelEl,
+    ([entry]) => {
+      if (!entry)
+        return
+      const stuck = entry.boundingClientRect.top <= 0 && !entry.isIntersecting
+      if (stuck && !isSearchStuck.value) {
+        const measured = searchRowEl.value?.offsetHeight
+        if (measured)
+          stuckRowHeight.value = measured
+      }
+      isSearchStuck.value = stuck
+    },
+    { threshold: 0 },
+  )
+
+  return {
+    isSearchStuck: readonly(isSearchStuck),
+    stuckRowHeight: readonly(stuckRowHeight),
+  }
+}

--- a/constants/homePlaceholders.ts
+++ b/constants/homePlaceholders.ts
@@ -1,0 +1,101 @@
+/**
+ * Плейсхолдеры для главной страницы.
+ *
+ * Сюда вынесено всё, что в дизайне (Homepage.dc.html) захардкожено и не имеет
+ * источника данных в текущей схеме. Каждый экспорт помечен комментарием
+ * `PLACEHOLDER —` с описанием бэкенд-работы, которая его закроет.
+ *
+ * Ничего «фактического» (сроки доставки, пороги, проценты) здесь выдумывать
+ * НЕЛЬЗЯ — только переносить уже проверенные значения из кода/оферты.
+ */
+
+/**
+ * PLACEHOLDER — дедлайна акции нет в схеме.
+ *
+ * Бэкенд-варианты (в порядке возрастания трудозатрат):
+ *   1. строка в `settings` c ключом 'product_of_the_day' и JSON
+ *      { product_id, starts_at, ends_at } — паттерн уже используется,
+ *      см. categoriesStore.ts (чтение key='additional_menu_items');
+ *   2. колонки `products.deal_ends_at timestamptz` + `products.deal_price numeric`;
+ *   3. отдельная таблица `deals_of_the_day` (product_id, starts_at, ends_at, is_active).
+ *
+ * Сам товар РЕАЛЬНЫЙ — берётся из productsStore.fetchFeaturedProducts(1).
+ * Фабрикуется только дедлайн: считаем до конца текущих локальных суток.
+ */
+export const DEAL_COUNTDOWN_MODE = 'end-of-local-day' as const
+
+/**
+ * Плитки выгод в блоке «Акции и бонусы».
+ *
+ * ⚠️ Копия выверена по коду, а не по прототипу:
+ *
+ * • «бесплатно от 15 000 ₸» — ПРАВДА: FREE_SHIPPING_THRESHOLD = 15000
+ *   (pages/checkout.vue). Значение продублировано здесь осознанно, потому что
+ *   константа объявлена локально в двух страницах; при вынесении в общий
+ *   модуль заменить импортом.
+ *
+ * • Срок доставки — в прототипе стоит «1–2 дня», но это ПРОТИВОРЕЧИТ
+ *   опубликованной оферте: pages/terms.vue → «По Алматы: 1-3 рабочих дня».
+ *   Публикуем цифру из оферты. Не менять без правки terms.vue.
+ *
+ * • Маршрута /delivery в проекте нет — ведём на раздел доставки в оферте.
+ */
+export const HOME_FREE_SHIPPING_THRESHOLD = 15000
+
+export const HOME_DELIVERY_TILE = {
+  id: 'delivery',
+  title: 'Доставка 1–3 дня',
+  subtitle: 'по Алматы, бесплатно от 15 000 ₸',
+  icon: 'lucide:truck',
+  href: '/terms',
+  accent: 'blue',
+} as const
+
+/**
+ * Плитка скидок. `title` НЕ захардкожен — процент подставляется из
+ * promo_campaigns.discount_percentage (таблица публично читаема,
+ * см. pages/promo/[slug].vue). Эти значения — фолбэк на случай,
+ * когда активных кампаний нет: тогда плитка ведёт в общий раздел акций
+ * и не утверждает конкретную цифру.
+ */
+export const HOME_DISCOUNT_TILE_FALLBACK = {
+  id: 'discounts',
+  title: 'Акции и распродажа',
+  subtitle: 'на хиты недели',
+  icon: 'lucide:badge-percent',
+  href: '/catalog/all?sort_by=discount',
+  accent: 'orange',
+} as const
+
+/**
+ * Быстрые чипы над лентой товаров.
+ *
+ * Первые три ведут в статические разделы каталога; остальные подмешиваются
+ * в рантайме из categoriesStore.menuTree, чтобы ни один чип не вёл в 404
+ * (в прототипе список захардкожен — Homepage.dc.html:577).
+ */
+export const HOME_STATIC_CHIPS = [
+  { id: 'all', label: 'Все', to: '/catalog/all' },
+  { id: 'new', label: 'Новинки', to: '/catalog/all?sort_by=newest' },
+  { id: 'popular', label: 'Популярное', to: '/catalog/all?sort_by=popularity' },
+] as const
+
+/** Сколько корневых категорий подмешать к статическим чипам. */
+export const HOME_CHIPS_CATEGORY_LIMIT = 5
+
+/**
+ * Тинты плиток категорий (Homepage.dc.html: CATCOL).
+ * Ключи — позиция корневой категории в menuTree, а не её slug:
+ * slug'и в проде отличаются от прототипа, привязка по индексу устойчивее.
+ */
+export const CATEGORY_TILE_TINTS = [
+  '#e3edfb', // мальчикам
+  '#f8ebf1', // девочкам
+  '#fbf0d1', // малышам
+  '#e5f2ea', // конструкторы
+  '#ede7fa', // творчество
+  '#fce8db', // активный отдых
+] as const
+
+export const CATEGORY_TILE_TINT_FALLBACK
+  = 'color-mix(in oklch, var(--primary) 10%, #fff)'

--- a/layouts/Catalog.vue
+++ b/layouts/Catalog.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <div class="hidden md:block">
-      <CommonHeader />
+    <div class="hidden lg:block">
+      <CommonSiteHeader />
     </div>
     <!-- Sticky таббар для мобильных -->
     <div class="lg:hidden sticky top-0 z-40">

--- a/layouts/CatalogListing.vue
+++ b/layouts/CatalogListing.vue
@@ -5,19 +5,13 @@ const LazyCommonFooter = defineAsyncComponent(() => import('@/components/common/
 
 <template>
   <div class="flex flex-col" style="min-height: 100dvh">
-    <!-- Header только на десктопе -->
+    <!-- Header только на десктопе; не sticky — на этой странице "прилипает" только CategoryScrollBar -->
     <div class="hidden lg:block">
-      <CommonSiteHeader />
+      <CommonSiteHeader :sticky="false" />
     </div>
 
-    <!-- Таббар только на мобильных -->
-    <div class="lg:hidden">
-      <CommonAppTabBarMobile />
-    </div>
-
-    <main
-      class="flex-1 lg:pt-0 pt-[76px] lg:pb-0 pb-[calc(4rem+env(safe-area-inset-bottom))]"
-    >
+    <!-- Мобильный тулбар — часть контента страницы (CategoryMobileHeader), не layout-chrome -->
+    <main class="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">
       <slot />
     </main>
 

--- a/layouts/Home.vue
+++ b/layouts/Home.vue
@@ -6,25 +6,57 @@ const LazyCommonFooter = defineAsyncComponent(() => import('@/components/common/
 
 <template>
   <div class="flex flex-col" style="min-height: 100dvh">
-    <!-- Header только на десктопе -->
+    <!--
+      Шапка только на десктопе, в режиме overlay: прозрачная поверх героя,
+      стекло при скролле. На мобильном шапки нет вовсе (как в дизайне) —
+      её роль играют фиксированный герой + липкая строка поиска + нижняя
+      навигация. NotificationBell перенесён в липкую строку поиска.
+    -->
     <div class="hidden lg:block">
-      <CommonHeader />
+      <CommonSiteHeader variant="overlay" />
     </div>
 
-    <!-- Мобильная версия с mobile header -->
-    <div class="lg:hidden">
-      <!-- Mobile Header - статичный -->
-      <CommonMobileHeader />
-    </div>
-
-    <!-- Main без padding-top, т.к. mobile header статичный -->
-    <main
-      class="flex-1 pt-[65px] lg:pt-0 lg:pb-0 pb-[calc(4rem+env(safe-area-inset-bottom))]"
-    >
+    <!--
+      Мобильный герой фиксирован (position:fixed) и начинается от y=0,
+      поэтому pt-* здесь быть НЕ должно. pb-* здесь тоже быть не должно:
+      резерв под нижнюю навигацию переехал на футер (см. ниже).
+    -->
+    <main class="flex-1">
       <slot />
     </main>
 
-    <!-- Footer — ленивый -->
-    <LazyCommonFooter />
+    <!--
+      Футер — ленивый, и обязан лежать в собственном слое.
+      Он рендерится ВНЕ <main>, поэтому белый лист `.home-content` (z-index: 6)
+      его не накрывает. Сам футер не спозиционирован, а мобильный герой —
+      `position: fixed; z-index: 0` (Hero.vue:214), поэтому без этого слоя футер
+      рисуется ПОД героем: внизу страницы герой просвечивал сквозь
+      полупрозрачный `bg-muted/30`. Фон обязан быть непрозрачным — одного
+      z-index мало. `mt-auto` переехал с самого <footer> на обёртку, иначе
+      он потерял бы flex-родителя.
+
+      Резерв под глобальную нижнюю навигацию (app.vue) висит ЗДЕСЬ, а не на
+      <main>. На <main> он давал 64px прозрачной полосы между листом контента
+      и футером, сквозь которую светил герой, и при этом не работал по
+      назначению: футер идёт после <main>, так что навигация всё равно
+      перекрывала его низ. Резерв должен стоять в самом конце документа.
+    -->
+    <div class="home-footer-layer mt-auto pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">
+      <LazyCommonFooter />
+    </div>
   </div>
 </template>
+
+<style scoped>
+.home-footer-layer {
+  position: relative;
+  /* Строго между фиксированным героем (z-index: 0) и листом контента
+     `.home-content` (z-index: 6). Ставить 6 нельзя: при равном z-index
+     побеждает тот, кто ниже в DOM, а футер идёт после <main> — он начинал
+     перекрывать липкую строку поиска. Её `.sticky-row--stuck { z-index: 100 }`
+     не спасает: строка заперта в стекинг-контексте `.home-content`, наружу
+     соревнуется весь лист целиком со своим z-index: 6. */
+  z-index: 1;
+  background: var(--background);
+}
+</style>

--- a/layouts/Internal.vue
+++ b/layouts/Internal.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- В этом макете мы просто вызываем хедер, НЕ передавая ничего в слот -->
-    <CommonHeader />
+    <CommonSiteHeader />
     <main>
       <slot />
     </main>

--- a/lib/variants.ts
+++ b/lib/variants.ts
@@ -4,6 +4,12 @@ import { cva } from 'class-variance-authority'
 /**
  * 🎨 Варианты контейнеров для каруселей и секций
  *
+ * Боковой отступ во всех вариантах берётся из --page-gutter
+ * (объявлена в assets/css/tailwind.css) — это единственный источник правды
+ * по ширине контента. Никаких «своих» px-* здесь быть не должно, иначе
+ * секции разъезжаются относительно рельсов, которые бликуют за край
+ * через margin-inline: calc(-1 * var(--page-gutter)).
+ *
  * contained: 'desktop' - На mobile full width (без padding), на desktop контейнер (для каруселей)
  * contained: 'always'  - Всегда ограниченный контейнер с padding (для заголовков, контента)
  * contained: false     - Всегда full width с padding (для обычных секций)
@@ -15,17 +21,20 @@ export const carouselContainerVariants = cva(
     variants: {
       // Размеры контейнера
       contained: {
-        // На mobile: full width БЕЗ padding, на desktop: ограниченный контейнер
-        // Используется для каруселей, чтобы карточки "выглядывали" на mobile
-        desktop: 'lg:container lg:max-w-screen-2xl lg:mx-auto lg:px-12',
+        // На mobile: full width БЕЗ padding, на desktop: ограниченный контейнер.
+        // Для лент каруселей до lg окно прокрутки обязано быть full-bleed,
+        // поэтому левый отступ живёт не здесь, а на самой флекс-ленте
+        // (см. components/global/ProductCarousel.vue): в покое первая карточка
+        // стоит по gutter'у, при листании карточки едут от края до края.
+        desktop: 'lg:container lg:max-w-screen-2xl lg:mx-auto lg:px-[var(--page-gutter)]',
 
         // Всегда ограниченный контейнер с padding на всех экранах
         // Используется для заголовков, текста, обычного контента
-        always: 'container max-w-screen-2xl mx-auto px-2 sm:px-6 md:px-8 lg:px-12',
+        always: 'container max-w-screen-2xl mx-auto px-[var(--page-gutter)]',
 
         // Всегда full width с padding на всех экранах
         // Используется для секций, которые должны занимать всю ширину
-        false: 'px-2 sm:px-6 md:px-8 lg:px-12',
+        false: 'px-[var(--page-gutter)]',
       },
     },
     defaultVariants: {
@@ -36,3 +45,27 @@ export const carouselContainerVariants = cva(
 
 // TypeScript тип для пропсов
 export type CarouselContainerVariants = VariantProps<typeof carouselContainerVariants>
+
+/**
+ * 📏 Вертикальные отступы секций (домашняя страница и т.п.)
+ *
+ * Единая шкала py-*, чтобы отступы обёртки в pages/index.vue и корневого
+ * <section> внутри соответствующего компонента всегда совпадали (иначе при
+ * переходе skeleton → контент высота блока «прыгает»).
+ */
+export const sectionSpacingVariants = cva('', {
+  variants: {
+    // Вертикальный ритм секции
+    size: {
+      xs: 'py-4', // стандартные секции (карусели, сетки категорий/брендов)
+      sm: 'py-8', // карточная карусель ProductCarousel (без десктоп-эскалации)
+      md: 'py-8 md:py-12', // акцентные секции (Акции и бонусы)
+      lg: 'py-12 md:py-16', // финальный SEO-блок
+    },
+  },
+  defaultVariants: {
+    size: 'xs',
+  },
+})
+
+export type SectionSpacingVariants = VariantProps<typeof sectionSpacingVariants>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -46,10 +46,17 @@ export default defineNuxtConfig({
   // @nuxt/fonts — font-display: swap убирает блокировку рендера шрифтами
   fonts: {
     defaults: {
-      weights: [400, 500, 600, 700],
+      // 800/900 нужны заголовкам и ценам в дизайне главной — без них
+      // браузер синтезирует псевдожирное начертание
+      weights: [400, 500, 600, 700, 800, 900],
       styles: ['normal'],
       subsets: ['cyrillic', 'latin'],
     },
+    families: [
+      // Montserrat Alternates используется только для логотипа-словомарки
+      // («Ухтышка» в шапке, подвале и на бонусной карте) — тянем один вес
+      { name: 'Montserrat Alternates', weights: [800] },
+    ],
     display: 'swap',
     // Предзагружаем шрифты для быстрого первого рендера
     preload: true,

--- a/pages/catalog/[...slug].vue
+++ b/pages/catalog/[...slug].vue
@@ -14,7 +14,15 @@ import type {
 } from '@/types'
 import { useQuery } from '@tanstack/vue-query'
 import { watchDebounced } from '@vueuse/core'
-import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  ref,
+  watch,
+} from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useSupabaseStorage } from '@/composables/menuItems/useSupabaseStorage'
 import { useCatalogQuery } from '@/composables/useCatalogQuery'
@@ -28,35 +36,36 @@ import { useCategoryQuestionsStore } from '@/stores/publicStore/categoryQuestion
 import { useProductsStore } from '@/stores/publicStore/productsStore'
 
 // ─── Ленивая загрузка тяжёлых компонентов ────────────────────────────────────
-// DynamicFilters: 28KB + DynamicFiltersMobile: 30KB — основные виновники
+// DynamicFilters: 28KB + MobileCatalogDrawer — основные виновники
 // Script Evaluation 1459ms на мобилке. Грузим только когда нужны.
-const DynamicFilters = defineAsyncComponent(() =>
-  import('@/components/global/DynamicFilters.vue'),
+const DynamicFilters = defineAsyncComponent(
+  () => import('@/components/global/DynamicFilters.vue'),
 )
-const DynamicFiltersMobile = defineAsyncComponent(() =>
-  import('@/components/global/DynamicFiltersMobile.vue'),
+const MobileCatalogDrawer = defineAsyncComponent(
+  () => import('@/components/category/MobileCatalogDrawer.vue'),
 )
 
 // Некритичные компоненты — грузим после первого рендера
-const CategoryBrands = defineAsyncComponent(() =>
-  import('@/components/category/CategoryBrands.vue'),
+const CategoryBrands = defineAsyncComponent(
+  () => import('@/components/category/CategoryBrands.vue'),
 )
-const CategoryProductLines = defineAsyncComponent(() =>
-  import('@/components/category/CategoryProductLines.vue'),
+const CategoryProductLines = defineAsyncComponent(
+  () => import('@/components/category/CategoryProductLines.vue'),
 )
-const CategoryQuestions = defineAsyncComponent(() =>
-  import('@/components/category/CategoryQuestions.vue'),
+const CategoryQuestions = defineAsyncComponent(
+  () => import('@/components/category/CategoryQuestions.vue'),
 )
-const CategoryRatingBlock = defineAsyncComponent(() =>
-  import('@/components/category/CategoryRatingBlock.vue'),
+const CategoryRatingBlock = defineAsyncComponent(
+  () => import('@/components/category/CategoryRatingBlock.vue'),
 )
-const CategoryReviews = defineAsyncComponent(() =>
-  import('@/components/category/CategoryReviews.vue'),
+const CategoryReviews = defineAsyncComponent(
+  () => import('@/components/category/CategoryReviews.vue'),
 )
-const SEOContentRenderer = defineAsyncComponent(() =>
-  import('@/components/category/SEOContentRenderer.vue'),
+const SEOContentRenderer = defineAsyncComponent(
+  () => import('@/components/category/SEOContentRenderer.vue'),
 )
 
+definePageMeta({ layout: 'catalog-listing' })
 
 // --- 1. Инициализация ---
 const route = useRoute()
@@ -67,7 +76,8 @@ const categoryQuestionsStore = useCategoryQuestionsStore()
 const containerClass = carouselContainerVariants({ contained: 'always' })
 const { getImageUrl, getVariantUrl } = useSupabaseStorage()
 const { sanitizeHtml } = useSafeHtml()
-const { generateBrandCategoryDescription, generateCategoryDescription } = useSeoTemplates()
+const { generateBrandCategoryDescription, generateCategoryDescription }
+  = useSeoTemplates()
 
 const priceValidUntil = new Date(
   new Date().setFullYear(new Date().getFullYear() + 1),
@@ -84,6 +94,33 @@ onUnmounted(() => {
   if (abortController.value) {
     abortController.value.abort()
   }
+})
+
+// ─── Плавающая кнопка «Наверх» на десктопе (из Категория.dc.html) ──────────────
+const showScrollTop = ref(false)
+let scrollTopTicking = false
+
+function applyScrollTopVisibility() {
+  scrollTopTicking = false
+  showScrollTop.value = window.scrollY > 560
+}
+
+function onWindowScroll() {
+  if (!scrollTopTicking) {
+    scrollTopTicking = true
+    requestAnimationFrame(applyScrollTopVisibility)
+  }
+}
+
+function scrollToTop() {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', onWindowScroll, { passive: true })
+})
+onUnmounted(() => {
+  window.removeEventListener('scroll', onWindowScroll)
 })
 
 function cleanDescription(html: string | null, maxLength = 200): string {
@@ -171,7 +208,8 @@ const numericAttributeRanges = ref<
 >({})
 const accumulatedProducts = ref<CatalogProduct[]>([])
 const isMobileFiltersOpen = ref(false)
-const isSubcategoriesDrawerOpen = ref(false)
+const isSortDrawerOpen = ref(false)
+const isSortPopoverOpen = ref(false)
 const isSeoTextExpanded = ref(false)
 
 interface ActiveFilters {
@@ -211,7 +249,7 @@ const filteredProductLines = computed(() => {
 
 // --- 3. Вычисляемые свойства ---
 const currentCategorySlug = computed(
-  () => (route.params.slug as string[]).slice(-1)[0] ?? 'all',
+  () => (route.params.slug as string[] | undefined)?.slice(-1)[0] ?? 'all',
 )
 
 const activeBrand = computed(() => {
@@ -294,24 +332,6 @@ const subcategories = computed(() =>
   categoriesStore.getSubcategories(currentCategorySlug.value),
 )
 
-const activeSubcategoryLabel = computed(() => {
-  const count = activeFilters.value.subCategoryIds.length
-  if (count === 0)
-    return 'Все категории'
-
-  const firstId = activeFilters.value.subCategoryIds[0]
-  const category = subcategories.value.find(c => c.id === firstId)
-
-  if (!category)
-    return 'Выбрано'
-
-  if (count > 1) {
-    return `${category.name} (+${count - 1})`
-  }
-
-  return category.name
-})
-
 const activeFiltersCount = computed(() => {
   let count = 0
   count += activeFilters.value.subCategoryIds.length
@@ -357,9 +377,10 @@ const activeFiltersCount = computed(() => {
 
 const canonicalUrl = computed(() => {
   const baseUrl = 'https://uhti.kz'
-  const basePath = currentCategory.value?.canonical_url
-    || currentCategory.value?.href
-    || route.path
+  const basePath
+    = currentCategory.value?.canonical_url
+      || currentCategory.value?.href
+      || route.path
 
   const hasUniqueSeoContent = activeBrandSlug.value && categoryBrandSeo.value
 
@@ -591,7 +612,9 @@ async function loadFilterData(slug: string) {
       availableBrands.value
         = brandsResult.status === 'fulfilled' ? brandsResult.value : []
       availableProductLines.value
-        = productLinesResult.status === 'fulfilled' ? productLinesResult.value : []
+        = productLinesResult.status === 'fulfilled'
+          ? productLinesResult.value
+          : []
       availableFilters.value = (
         attributesResult.status === 'fulfilled' ? attributesResult.value : []
       ) as FilterAttribute[]
@@ -831,6 +854,53 @@ function clearAttributeFilter(attributeSlug: string) {
   }
 }
 
+// ─── Сортировка — стеклянная пилюля из CatalogFilterBar.dc.html (десктоп) ──────
+const catalogSortOptions: { value: SortByType, label: string }[] = [
+  { value: 'popularity', label: 'Популярные' },
+  { value: 'newest', label: 'По новизне' },
+  { value: 'price_asc', label: 'Цена: по возрастанию' },
+  { value: 'price_desc', label: 'Цена: по убыванию' },
+]
+
+const currentSortLabel = computed(
+  () =>
+    catalogSortOptions.find(o => o.value === activeFilters.value.sortBy)
+      ?.label ?? catalogSortOptions[0].label,
+)
+
+function selectCatalogSort(value: SortByType) {
+  activeFilters.value = { ...activeFilters.value, sortBy: value }
+  isSortPopoverOpen.value = false
+}
+
+// ─── Бренды — вторая пилюля из CatalogFilterBar.dc.html (десктоп) ──────────────
+const isBrandPopoverOpen = ref(false)
+
+// Только один из двух поповеров бара открыт одновременно — тот же приём,
+// что и в CategoryScrollBar.vue для пары «Сортировка»/«Категории».
+watch(isSortPopoverOpen, (open) => {
+  if (open)
+    isBrandPopoverOpen.value = false
+})
+watch(isBrandPopoverOpen, (open) => {
+  if (open)
+    isSortPopoverOpen.value = false
+})
+
+function toggleCatalogBrand(checked: boolean, brandId: string) {
+  const current = activeFilters.value.brandIds
+  const next = checked
+    ? [...current, brandId]
+    : current.filter(id => id !== brandId)
+  activeFilters.value = { ...activeFilters.value, brandIds: next }
+}
+
+// CategoryScrollBar's list toggles by id only (no separate checked flag),
+// same shape as toggleSubCategory below — compute checked from current state.
+function toggleCatalogBrandById(brandId: string) {
+  toggleCatalogBrand(!activeFilters.value.brandIds.includes(brandId), brandId)
+}
+
 function toggleSubCategory(catId: string) {
   const newIds = new Set(activeFilters.value.subCategoryIds)
   if (newIds.has(catId)) {
@@ -850,7 +920,9 @@ function resetAllFilters() {
     sortBy: 'popularity',
     subCategoryIds: [],
     price: [priceRange.value.min, priceRange.value.max],
-    pieceCount: pieceCountRange.value ? [pieceCountRange.value.min, pieceCountRange.value.max] : null,
+    pieceCount: pieceCountRange.value
+      ? [pieceCountRange.value.min, pieceCountRange.value.max]
+      : null,
     brandIds: [],
     productLineIds: [],
     materialIds: [],
@@ -995,7 +1067,8 @@ const metaDescription = computed(() => {
       brandSlug: activeBrand.value.slug,
       categoryName: categoryName.value,
       categorySlug: currentCategorySlug.value,
-      productsCount: categoryBrandSeo.value.products_count || displayedProducts.value.length,
+      productsCount:
+        categoryBrandSeo.value.products_count || displayedProducts.value.length,
       minPrice: categoryBrandSeo.value.min_price || minPrice.value || 0,
       maxPrice: categoryBrandSeo.value.min_price || 0,
       rating: categoryBrandSeo.value.avg_rating || undefined,
@@ -1004,7 +1077,9 @@ const metaDescription = computed(() => {
   }
 
   if (currentCategory.value?.meta_description) {
-    let cleanText = currentCategory.value.meta_description.replace(/<[^>]*>/g, '').trim()
+    let cleanText = currentCategory.value.meta_description
+      .replace(/<[^>]*>/g, '')
+      .trim()
 
     const hasBrandMentions = topBrands.value.some(brand =>
       cleanText.toLowerCase().includes(brand.toLowerCase()),
@@ -1015,7 +1090,8 @@ const metaDescription = computed(() => {
       if (firstSentenceEnd > 0 && firstSentenceEnd < 60) {
         const firstPart = cleanText.substring(0, firstSentenceEnd + 1)
         const brandsText = ` (${topBrands.value.join(', ')})`
-        cleanText = firstPart + brandsText + cleanText.substring(firstSentenceEnd + 1)
+        cleanText
+          = firstPart + brandsText + cleanText.substring(firstSentenceEnd + 1)
       }
       else {
         cleanText = `${cleanText.substring(0, 50)} (${topBrands.value.join(', ')})`
@@ -1025,7 +1101,10 @@ const metaDescription = computed(() => {
     const maxBaseLength = 80
     if (cleanText.length > maxBaseLength) {
       const cutPoint = cleanText.lastIndexOf(' ', maxBaseLength)
-      cleanText = cutPoint > 50 ? cleanText.substring(0, cutPoint) : cleanText.substring(0, maxBaseLength)
+      cleanText
+        = cutPoint > 50
+          ? cleanText.substring(0, cutPoint)
+          : cleanText.substring(0, maxBaseLength)
     }
 
     if (cleanText.endsWith('.')) {
@@ -1035,14 +1114,19 @@ const metaDescription = computed(() => {
     const parts = [cleanText]
 
     if (minPrice.value) {
-      parts.push(`💰 Цены от ${new Intl.NumberFormat('ru-RU').format(minPrice.value)} ₸`)
+      parts.push(
+        `💰 Цены от ${new Intl.NumberFormat('ru-RU').format(minPrice.value)} ₸`,
+      )
     }
 
     if (categoryStats.value.reviews > 0) {
-      const ratingValue = Number.parseFloat(categoryStats.value.rating.replace(',', '.')) || 5
+      const ratingValue
+        = Number.parseFloat(categoryStats.value.rating.replace(',', '.')) || 5
       const starCount = Math.round(ratingValue)
       const starEmojis = '⭐'.repeat(starCount)
-      parts.push(`${starEmojis} ${categoryStats.value.rating} (${categoryStats.value.reviews} отз)`)
+      parts.push(
+        `${starEmojis} ${categoryStats.value.rating} (${categoryStats.value.reviews} отз)`,
+      )
     }
 
     parts.push('Быстрая доставка по Алматы за 1 день. Заказывайте оригиналы!')
@@ -1052,9 +1136,10 @@ const metaDescription = computed(() => {
   }
 
   if (!hasActiveFilters.value && minPrice.value && topBrands.value.length > 0) {
-    const ratingValue = categoryStats.value.reviews > 0
-      ? Number.parseFloat(categoryStats.value.rating.replace(',', '.'))
-      : undefined
+    const ratingValue
+      = categoryStats.value.reviews > 0
+        ? Number.parseFloat(categoryStats.value.rating.replace(',', '.'))
+        : undefined
 
     return generateCategoryDescription({
       categoryName: categoryName.value,
@@ -1062,7 +1147,10 @@ const metaDescription = computed(() => {
       minPrice: minPrice.value,
       city: 'Алматы',
       rating: ratingValue,
-      reviewsCount: categoryStats.value.reviews > 0 ? categoryStats.value.reviews : undefined,
+      reviewsCount:
+        categoryStats.value.reviews > 0
+          ? categoryStats.value.reviews
+          : undefined,
     })
   }
 
@@ -1080,7 +1168,8 @@ const metaDescription = computed(() => {
   }
 
   if (categoryStats.value.reviews > 0) {
-    const ratingValue = Number.parseFloat(categoryStats.value.rating.replace(',', '.')) || 5
+    const ratingValue
+      = Number.parseFloat(categoryStats.value.rating.replace(',', '.')) || 5
     const starCount = Math.round(ratingValue)
     const starEmojis = '⭐'.repeat(starCount)
     snippet += `. ${starEmojis} ${categoryStats.value.rating} (${categoryStats.value.reviews} отз)`
@@ -1103,7 +1192,9 @@ const metaTitle = computed(() => {
         ? catName
         : `${catName} ${brandName}`
 
-    const priceText = minPrice.value ? ` — от ${formatPrice(minPrice.value)} ₸` : ''
+    const priceText = minPrice.value
+      ? ` — от ${formatPrice(minPrice.value)} ₸`
+      : ''
     return `${prefix}${priceText} | Ухтышка`
   }
 
@@ -1111,7 +1202,9 @@ const metaTitle = computed(() => {
     const brandName = selectedSingleBrand.value?.name || ''
     const lineName = selectedSingleLine.value.name
     const prefix = brandName ? `${brandName} ${lineName}` : lineName
-    const priceText = minPrice.value ? ` — от ${formatPrice(minPrice.value)} ₸` : ''
+    const priceText = minPrice.value
+      ? ` — от ${formatPrice(minPrice.value)} ₸`
+      : ''
     return `${prefix}${priceText} | Ухтышка`
   }
 
@@ -1176,21 +1269,23 @@ const robotsRule = computed(() => {
 })
 
 // --- 5. Загрузка данных ---
-const [{ data: _categoriesData }, { data: _filterPayload }] = await Promise.all([
-  useAsyncData(
-    `catalog-meta-${currentCategorySlug.value}`,
-    () => categoriesStore.fetchCategoryData(),
-    { watch: [currentCategorySlug] },
-  ),
-  useAsyncData(
-    `catalog-filters-${currentCategorySlug.value}`,
-    () => loadFilterData(currentCategorySlug.value),
-    {
-      watch: [currentCategorySlug],
-      server: true,
-    },
-  ),
-])
+const [{ data: _categoriesData }, { data: _filterPayload }] = await Promise.all(
+  [
+    useAsyncData(
+      `catalog-meta-${currentCategorySlug.value}`,
+      () => categoriesStore.fetchCategoryData(),
+      { watch: [currentCategorySlug] },
+    ),
+    useAsyncData(
+      `catalog-filters-${currentCategorySlug.value}`,
+      () => loadFilterData(currentCategorySlug.value),
+      {
+        watch: [currentCategorySlug],
+        server: true,
+      },
+    ),
+  ],
+)
 
 if (import.meta.client && _filterPayload.value) {
   availableBrands.value = _filterPayload.value.brands
@@ -1351,15 +1446,6 @@ useBreadcrumbSchema(
 useHead(() => {
   const links: any[] = [{ rel: 'canonical', href: canonicalUrl.value }]
 
-  if (categoryOgImageUrl.value && (currentCategory.value?.description || seoText.value)) {
-    links.push({
-      rel: 'preload',
-      as: 'image',
-      href: categoryOgImageUrl.value,
-      fetchpriority: 'high',
-    })
-  }
-
   return {
     meta: [{ name: 'keywords', content: metaKeywords.value || '' }],
     link: links,
@@ -1479,7 +1565,8 @@ const schemaData = computed(() => {
               'hasMerchantReturnPolicy': {
                 '@type': 'MerchantReturnPolicy',
                 'applicableCountry': 'KZ',
-                'returnPolicyCategory': 'https://schema.org/MerchantReturnFiniteReturnWindow',
+                'returnPolicyCategory':
+                  'https://schema.org/MerchantReturnFiniteReturnWindow',
                 'merchantReturnDays': 14,
                 'returnMethod': 'https://schema.org/ReturnByMail',
                 'returnFees': 'https://schema.org/FreeReturn',
@@ -1545,6 +1632,24 @@ else {
 </script>
 
 <template>
+  <CategoryMobileHeader
+    :sort-active="isSortDrawerOpen"
+    :filters-active="isMobileFiltersOpen"
+    :has-active-filters="activeFiltersCount > 0"
+    @sort="isSortDrawerOpen = true"
+    @filters="isMobileFiltersOpen = true"
+  />
+
+  <CategoryScrollBar
+    v-model:sort-by="activeFilters.sortBy"
+    :subcategories="subcategories"
+    :active-subcategory-ids="activeFilters.subCategoryIds"
+    :brands="availableBrands"
+    :active-brand-ids="activeFilters.brandIds"
+    @toggle-subcategory="toggleSubCategory"
+    @toggle-brand="toggleCatalogBrandById"
+  />
+
   <div :class="`${containerClass} py-4 lg:py-8`">
     <!-- ─── ОПТИМИЗАЦИЯ: убрали ClientOnly — breadcrumbs доступны на сервере ─── -->
     <!-- ClientOnly скрывал хлебные крошки до гидрации, увеличивая FCP -->
@@ -1555,118 +1660,20 @@ else {
       compact
     />
 
-    <!-- Блок с картинкой и описанием категории -->
-    <div
-      v-if="currentCategory && (currentCategory.description || seoText)"
-      class="bg-white dark:bg-card rounded-xl p-4 lg:p-8 mb-6 lg:mb-8 border shadow-sm"
+    <!-- ЕДИНСТВЕННЫЙ H1 ДЛЯ SEO И ЛЮДЕЙ -->
+    <h1
+      class="text-xl md:text-3xl font-bold mb-1 lg:mb-2 transition-opacity duration-200"
+      :class="brandSeoLoading ? 'opacity-0' : 'opacity-100'"
     >
-      <!-- ЕДИНСТВЕННЫЙ H1 ДЛЯ SEO И ЛЮДЕЙ -->
-      <h1
-        class="text-xl md:text-3xl font-bold mb-4 transition-opacity duration-200"
-        :class="brandSeoLoading ? 'opacity-0' : 'opacity-100'"
-      >
-        {{ title }}
-      </h1>
-
-      <div class="flex flex-col lg:flex-row gap-4 lg:gap-6 items-start">
-        <!-- Картинка — fetchpriority="high" ускоряет LCP -->
-        <div
-          v-if="currentCategory.image_url"
-          class="shrink-0 w-16 h-16 lg:w-[220px] lg:h-[160px] rounded-lg overflow-hidden shadow-sm lg:shadow-md bg-gray-50 dark:bg-gray-900 flex items-center justify-center"
-        >
-          <ProgressiveImage
-            :src="
-              getVariantUrl(
-                BUCKET_NAME_CATEGORY,
-                currentCategory.image_url,
-                'md',
-              )
-            "
-            :alt="currentCategory.name"
-            object-fit="contain"
-            placeholder-type="lqip"
-            :blur-data-url="currentCategory.blur_placeholder || undefined"
-            :eager="true"
-            fetchpriority="high"
-            class="w-full h-full"
-          />
-        </div>
-
-        <!-- Текстовый блок и статистика -->
-        <div class="flex-1 space-y-3 lg:space-y-4 w-full">
-          <!-- Рейтинг категории -->
-          <CategoryRatingBlock
-            v-if="showCategoryRating"
-            :avg-rating="categoryRatingData!.avg_rating"
-            :total-reviews="categoryRatingData!.total_reviews"
-          />
-
-          <!-- Описание категории из БД -->
-          <p
-            v-if="currentCategory.description"
-            class="text-sm lg:text-base text-muted-foreground leading-relaxed line-clamp-2 lg:line-clamp-none"
-          >
-            {{ currentCategory.description }}
-          </p>
-
-          <!-- SEO текст (HTML) -->
-          <div
-            v-else-if="seoText"
-            class="text-sm lg:text-base text-muted-foreground leading-relaxed line-clamp-2 lg:line-clamp-none prose prose-sm lg:prose max-w-none"
-            v-html="seoText"
-          />
-
-          <!-- Счётчики с защитой от hydration mismatch -->
-          <ClientOnly>
-            <div class="flex flex-wrap items-center gap-3 lg:gap-4 pt-2 text-xs lg:text-sm text-muted-foreground">
-              <div class="flex items-center gap-1.5 lg:gap-2 min-w-[60px]">
-                <Icon name="lucide:package" class="w-3.5 h-3.5 lg:w-4 lg:h-4 text-blue-500" />
-                <span>{{ displayedProducts.length || '—' }} <span class="hidden lg:inline">товаров</span></span>
-              </div>
-              <div
-                v-if="availableBrands.length > 0"
-                class="flex items-center gap-1.5 lg:gap-2 min-w-[60px]"
-              >
-                <Icon name="lucide:award" class="w-3.5 h-3.5 lg:w-4 lg:h-4 text-purple-500" />
-                <span>{{ availableBrands.length }} <span class="hidden lg:inline">брендов</span></span>
-              </div>
-              <div
-                v-if="priceRange.min > 0 || priceRange.max < 50000"
-                class="flex items-center gap-1.5 lg:gap-2"
-              >
-                <Icon name="lucide:tag" class="w-3.5 h-3.5 lg:w-4 lg:h-4 text-green-500" />
-                <span>от {{ new Intl.NumberFormat("ru-RU").format(priceRange.min) }} ₸</span>
-              </div>
-            </div>
-            <template #fallback>
-              <div class="flex flex-wrap items-center gap-3 lg:gap-4 pt-2 text-xs lg:text-sm text-muted-foreground min-h-[20px]">
-                <div class="flex items-center gap-1.5 lg:gap-2 min-w-[60px]">
-                  <Icon name="lucide:package" class="w-3.5 h-3.5 lg:w-4 lg:h-4 text-blue-500" />
-                  <span>— <span class="hidden lg:inline">товаров</span></span>
-                </div>
-              </div>
-            </template>
-          </ClientOnly>
-        </div>
-      </div>
-    </div>
-
-    <!-- Заголовок для случая с активными фильтрами или без описания -->
-    <template v-else>
-      <h1
-        class="text-xl md:text-3xl font-bold mb-1 lg:mb-2 transition-opacity duration-200"
-        :class="brandSeoLoading ? 'opacity-0' : 'opacity-100'"
-      >
-        {{ title }}
-      </h1>
-      <CategoryRatingBlock
-        v-if="showCategoryRating"
-        :avg-rating="categoryRatingData!.avg_rating"
-        :total-reviews="categoryRatingData!.total_reviews"
-        class="mb-3 lg:mb-4"
-      />
-      <div v-else class="mb-3 lg:mb-4" />
-    </template>
+      {{ title }}
+    </h1>
+    <CategoryRatingBlock
+      v-if="showCategoryRating"
+      :avg-rating="categoryRatingData!.avg_rating"
+      :total-reviews="categoryRatingData!.total_reviews"
+      class="mb-3 lg:mb-4"
+    />
+    <div v-else class="mb-3 lg:mb-4" />
 
     <!-- Бренды как 3-й уровень навигации (перед товарами) -->
     <CategoryBrands
@@ -1721,104 +1728,66 @@ else {
 
       <div class="col-span-1 lg:col-span-3 min-w-0">
         <div class="mb-6 space-y-4">
-          <!-- Подкатегории на мобильных -->
-          <div v-if="subcategories.length > 0" class="lg:hidden">
-            <div class="flex items-center justify-between gap-2">
-              <Button
-                variant="outline"
-                class="inline-flex flex-1 items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-lg shadow-blue-500/25 hover:shadow-purple-500/40 transition-all duration-200 whitespace-nowrap shrink-0 snap-start hover:scale-[1.02] active:scale-95"
-                @click="isSubcategoriesDrawerOpen = true"
-              >
-                <Icon
-                  :name="
-                    activeFilters.subCategoryIds.length > 0
-                      ? 'lucide:layers'
-                      : 'lucide:grid-2x2'
-                  "
-                  class="w-4 h-4 shrink-0"
-                />
-                <span class="truncate">{{ activeSubcategoryLabel }}</span>
-              </Button>
-
-              <Button
-                variant="ghost"
-                size="icon"
-                :disabled="activeFilters.subCategoryIds.length === 0"
-                class="inline-flex items-center gap-2 rounded-xl text-sm font-medium bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-lg shadow-blue-500/25 hover:shadow-purple-500/40 transition-all duration-200 whitespace-nowrap shrink-0 snap-start hover:scale-[1.02] active:scale-95"
-                @click="activeFilters.subCategoryIds = []"
-              >
-                <Icon name="lucide:x" class="w-5 h-5" />
-              </Button>
-            </div>
+          <!-- Подкатегории на мобильных — горизонтальная лента чипов, из Категория.dc.html -->
+          <div
+            v-if="subcategories.length > 0"
+            class="flex lg:hidden cf-chip-scroller"
+          >
+            <button
+              v-for="cat in subcategories"
+              :key="cat.id"
+              type="button"
+              class="cf-chip"
+              :class="{
+                'cf-chip--active': activeFilters.subCategoryIds.includes(
+                  cat.id,
+                ),
+              }"
+              @click="toggleSubCategory(cat.id)"
+            >
+              {{ cat.name }}
+            </button>
           </div>
 
-          <!-- Панель управления -->
-          <div class="flex flex-wrap items-center gap-2">
-            <ClientOnly>
-              <Button
-                :variant="activeFiltersCount > 0 ? 'default' : 'outline'"
-                class="lg:hidden h-11 w-11 p-0 shrink-0 relative transition-colors"
-                :class="[
-                  activeFiltersCount > 0
-                    ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500'
-                    : '',
-                ]"
-                @click="isMobileFiltersOpen = true"
-              >
-                <Icon name="lucide:sliders-horizontal" class="w-5 h-5" />
-                <Badge
-                  v-if="activeFiltersCount > 0"
-                  variant="secondary"
-                  class="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs bg-white text-blue-500 border-2 border-blue-500"
-                >
-                  {{ activeFiltersCount }}
-                </Badge>
-              </Button>
-            </ClientOnly>
-
-            <CatalogHeader v-model:sort-by="activeFilters.sortBy" />
-
-            <div
-              v-if="!isLoadingFilters && availableFilters.length > 0"
-              class="h-6 w-px bg-border hidden lg:block"
-            />
-
-            <template v-if="!isLoadingFilters && availableFilters.length > 0">
+          <!-- Атрибутные фильтры (в потоке, не sticky) — сортировка и чипы подкатегорий
+               теперь в статичном баре CatalogFilterBar над breadcrumbs. Скрываем весь
+               блок целиком, если показывать нечего — иначе остаётся пустая полоса
+               с бордером (сортировка раньше всегда заполняла эту строку). -->
+          <div
+            v-if="!isLoadingFilters && displayableFilters.length > 0"
+            class="lg:bg-white dark:lg:bg-card lg:py-3 lg:border-b lg:border-border"
+          >
+            <div class="flex flex-wrap items-center gap-2">
               <template v-for="filter in displayableFilters" :key="filter.id">
                 <!-- Select type -->
                 <Popover v-if="filter.display_type === 'select'">
                   <PopoverTrigger as-child>
-                    <Button
-                      :variant="
-                        (activeFilters.attributes[filter.slug] || []).length > 0
-                          ? 'default'
-                          : 'outline'
-                      "
-                      class="hidden lg:inline-flex h-11 gap-2 transition-colors"
-                      :class="[
-                        (activeFilters.attributes[filter.slug] || []).length > 0
-                          ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500'
-                          : '',
-                      ]"
+                    <button
+                      type="button"
+                      class="cf-glass-btn hidden lg:inline-flex"
+                      :class="{
+                        'cf-glass-btn--active':
+                          (activeFilters.attributes[filter.slug] || []).length
+                          > 0,
+                      }"
                     >
                       {{ filter.name }}
-                      <Badge
+                      <span
                         v-if="
                           (activeFilters.attributes[filter.slug] || []).length
                             > 0
                         "
-                        variant="secondary"
-                        class="h-5 min-w-5 flex items-center justify-center p-0 px-1.5 text-xs bg-white text-blue-500"
+                        class="cf-glass-badge"
                       >
                         {{
                           (activeFilters.attributes[filter.slug] || []).length
                         }}
-                      </Badge>
+                      </span>
                       <Icon
                         name="lucide:chevron-down"
-                        class="w-3.5 h-3.5 opacity-50"
+                        class="w-3.5 h-3.5 opacity-60"
                       />
-                    </Button>
+                    </button>
                   </PopoverTrigger>
                   <PopoverContent class="w-64 p-3" align="start">
                     <div class="space-y-2">
@@ -1876,37 +1845,32 @@ else {
                 <!-- Color type -->
                 <Popover v-else-if="filter.display_type === 'color'">
                   <PopoverTrigger as-child>
-                    <Button
-                      :variant="
-                        (activeFilters.attributes[filter.slug] || []).length > 0
-                          ? 'default'
-                          : 'outline'
-                      "
-                      class="hidden lg:inline-flex h-11 gap-2 transition-colors"
-                      :class="[
-                        (activeFilters.attributes[filter.slug] || []).length > 0
-                          ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500'
-                          : '',
-                      ]"
+                    <button
+                      type="button"
+                      class="cf-glass-btn hidden lg:inline-flex"
+                      :class="{
+                        'cf-glass-btn--active':
+                          (activeFilters.attributes[filter.slug] || []).length
+                          > 0,
+                      }"
                     >
                       {{ filter.name }}
-                      <Badge
+                      <span
                         v-if="
                           (activeFilters.attributes[filter.slug] || []).length
                             > 0
                         "
-                        variant="secondary"
-                        class="h-5 min-w-5 flex items-center justify-center p-0 px-1.5 text-xs bg-white text-blue-500"
+                        class="cf-glass-badge"
                       >
                         {{
                           (activeFilters.attributes[filter.slug] || []).length
                         }}
-                      </Badge>
+                      </span>
                       <Icon
                         name="lucide:chevron-down"
-                        class="w-3.5 h-3.5 opacity-50"
+                        class="w-3.5 h-3.5 opacity-60"
                       />
-                    </Button>
+                    </button>
                   </PopoverTrigger>
                   <PopoverContent class="w-64 p-3" align="start">
                     <div class="space-y-3">
@@ -1966,36 +1930,120 @@ else {
                   </PopoverContent>
                 </Popover>
               </template>
-            </template>
+            </div>
+          </div>
 
-            <!-- Подкатегории на десктопе -->
-            <template v-if="subcategories.length > 0">
-              <div class="hidden lg:block h-6 w-px bg-border" />
+          <!-- Сортировка + бренды + чипы подкатегорий (десктоп) — над сеткой
+               товаров, из CatalogFilterBar.dc.html. Без фона: просто ряд пилюль. -->
+          <div class="hidden lg:flex items-center gap-2">
+            <CatalogHeader
+              v-model:sort-by="activeFilters.sortBy"
+              v-model:open="isSortDrawerOpen"
+              hide-mobile-trigger
+              hide-desktop-trigger
+            />
+
+            <Popover v-model:open="isSortPopoverOpen">
+              <PopoverTrigger as-child>
+                <button
+                  type="button"
+                  class="cf-glass-btn"
+                  :class="{
+                    'cf-glass-btn--active': activeFilters.sortBy !== 'popularity',
+                  }"
+                >
+                  {{ currentSortLabel }}
+                  <Icon
+                    name="lucide:chevron-down"
+                    class="w-3.5 h-3.5 opacity-60 transition-transform"
+                    :class="{ 'rotate-180': isSortPopoverOpen }"
+                  />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                class="w-56 p-1.5 rounded-2xl shadow-xl flex flex-col gap-0.5"
+              >
+                <button
+                  v-for="option in catalogSortOptions"
+                  :key="option.value"
+                  type="button"
+                  class="w-full flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors hover:bg-accent"
+                  :class="{ 'font-bold': activeFilters.sortBy === option.value }"
+                  @click="selectCatalogSort(option.value)"
+                >
+                  {{ option.label }}
+                  <Icon
+                    v-if="activeFilters.sortBy === option.value"
+                    name="lucide:check"
+                    class="w-4 h-4 text-primary"
+                  />
+                </button>
+              </PopoverContent>
+            </Popover>
+
+            <Popover v-if="availableBrands.length > 0" v-model:open="isBrandPopoverOpen">
+              <PopoverTrigger as-child>
+                <button
+                  type="button"
+                  class="cf-glass-btn"
+                  :class="{ 'cf-glass-btn--active': activeFilters.brandIds.length > 0 }"
+                >
+                  Бренды
+                  <span v-if="activeFilters.brandIds.length > 0" class="cf-glass-badge">
+                    {{ activeFilters.brandIds.length }}
+                  </span>
+                  <Icon
+                    name="lucide:chevron-down"
+                    class="w-3.5 h-3.5 opacity-60 transition-transform"
+                    :class="{ 'rotate-180': isBrandPopoverOpen }"
+                  />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                class="w-60 p-1.5 rounded-2xl shadow-xl flex flex-col gap-1 max-h-80 overflow-y-auto"
+              >
+                <div
+                  v-for="brand in availableBrands"
+                  :key="brand.id"
+                  class="flex items-center gap-2.5 px-2 py-1.5 rounded-lg hover:bg-accent"
+                >
+                  <Checkbox
+                    :id="`cfb-brand-${brand.id}`"
+                    :model-value="activeFilters.brandIds.includes(brand.id)"
+                    @update:model-value="(checked) => toggleCatalogBrand(!!checked, brand.id)"
+                  />
+                  <Label
+                    :for="`cfb-brand-${brand.id}`"
+                    class="flex-1 min-w-0 flex items-center justify-between gap-2 font-normal cursor-pointer text-sm"
+                  >
+                    <span class="truncate">{{ brand.name }}</span>
+                    <span v-if="brand.products_count" class="text-xs text-muted-foreground shrink-0">
+                      {{ brand.products_count }}
+                    </span>
+                  </Label>
+                </div>
+              </PopoverContent>
+            </Popover>
+
+            <div
+              v-if="subcategories.length > 0"
+              class="flex cf-chip-scroller flex-1 min-w-0"
+            >
               <button
                 v-for="cat in subcategories"
                 :key="cat.id"
                 type="button"
-                class="hidden lg:inline-flex group relative items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 whitespace-nowrap shrink-0"
-                :class="[
-                  activeFilters.subCategoryIds.includes(cat.id)
-                    ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-lg shadow-blue-500/25 scale-[1.02]'
-                    : 'bg-secondary/60 text-secondary-foreground hover:bg-secondary hover:scale-[1.02] hover:shadow-md active:scale-95',
-                ]"
+                class="cf-chip"
+                :class="{
+                  'cf-chip--active': activeFilters.subCategoryIds.includes(cat.id),
+                }"
                 @click="toggleSubCategory(cat.id)"
               >
-                <div
-                  v-if="activeFilters.subCategoryIds.includes(cat.id)"
-                  class="flex items-center justify-center w-4 h-4 rounded-full bg-white/20"
-                >
-                  <Icon name="lucide:check" class="w-3 h-3" />
-                </div>
-                <span>{{ cat.name }}</span>
-                <div
-                  v-if="!activeFilters.subCategoryIds.includes(cat.id)"
-                  class="absolute inset-0 rounded-xl border-2 border-transparent group-hover:border-primary/20 transition-colors"
-                />
+                {{ cat.name }}
               </button>
-            </template>
+            </div>
           </div>
         </div>
 
@@ -2014,59 +2062,74 @@ else {
               />
 
               <div v-else-if="displayedProducts.length > 0" class="space-y-8">
-              <ProductGrid :products="displayedProducts" />
+                <ProductGrid :products="displayedProducts" />
 
-              <div v-if="hasMore" class="text-center">
-                <Button
-                  variant="outline"
-                  size="lg"
-                  :disabled="isFetching"
-                  @click="loadMoreProducts"
+                <div v-if="hasMore" class="text-center">
+                  <button
+                    type="button"
+                    class="cf-glass-btn cf-glass-btn--lg"
+                    :disabled="isFetching"
+                    @click="loadMoreProducts"
+                  >
+                    <span v-if="isFetching">Загрузка...</span>
+                    <template v-else>
+                      <span>Показать ещё</span>
+                      <Icon name="lucide:chevron-down" class="w-4 h-4" />
+                    </template>
+                  </button>
+                </div>
+
+                <div
+                  v-if="isFetching && currentPage > 1"
+                  class="text-center text-sm text-muted-foreground"
                 >
-                  <span v-if="isFetching">Загрузка...</span>
-                  <span v-else>Показать ещё</span>
-                </Button>
+                  Загрузка товаров...
+                </div>
               </div>
 
               <div
-                v-if="isFetching && currentPage > 1"
-                class="text-center text-sm text-muted-foreground"
+                v-else
+                class="text-center py-16 bg-white dark:bg-card border border-border rounded-[22px]"
               >
-                Загрузка товаров...
+                <div
+                  class="w-16 h-16 rounded-full bg-muted flex items-center justify-center mx-auto mb-4"
+                >
+                  <Icon
+                    name="lucide:package-open"
+                    class="w-7 h-7 text-muted-foreground"
+                  />
+                </div>
+                <h3 class="text-xl font-bold">
+                  {{
+                    hasActiveFilters
+                      ? "Товары не найдены"
+                      : "Скоро здесь появятся товары"
+                  }}
+                </h3>
+                <p class="mt-2 text-sm text-muted-foreground">
+                  {{
+                    hasActiveFilters
+                      ? "Попробуйте изменить фильтры или выбрать другую категорию."
+                      : "Мы работаем над наполнением этой категории. Загляните позже!"
+                  }}
+                </p>
+                <button
+                  v-if="hasActiveFilters"
+                  type="button"
+                  class="cf-glass-btn cf-glass-btn--primary mt-5"
+                  @click="resetAllFilters"
+                >
+                  <Icon name="lucide:x" class="w-4 h-4" />
+                  Сбросить все фильтры
+                </button>
               </div>
             </div>
+          </Transition>
 
-            <div
-              v-else
-              class="text-center py-20 text-muted-foreground border-2 border-dashed rounded-lg"
-            >
-              <Icon name="lucide:package-open" class="w-16 h-16 mx-auto mb-4 text-muted-foreground/50" />
-              <h3 class="text-2xl font-semibold">
-                {{ hasActiveFilters ? 'Товары не найдены' : 'Скоро здесь появятся товары' }}
-              </h3>
-              <p class="mt-2">
-                {{ hasActiveFilters
-                  ? 'Попробуйте изменить фильтры или выбрать другую категорию.'
-                  : 'Мы работаем над наполнением этой категории. Загляните позже!'
-                }}
-              </p>
-              <Button
-                v-if="hasActiveFilters"
-                variant="outline"
-                class="mt-4"
-                @click="resetAllFilters"
-              >
-                <Icon name="lucide:x" class="w-4 h-4 mr-2" />
-                Сбросить все фильтры
-              </Button>
-            </div>
-          </div>
-        </Transition>
-
-        <template #fallback>
-          <ProductGridSkeleton />
-        </template>
-      </ClientOnly>
+          <template #fallback>
+            <ProductGridSkeleton />
+          </template>
+        </ClientOnly>
       </div>
     </div>
 
@@ -2118,8 +2181,8 @@ else {
 
     <!-- Мобильные компоненты -->
     <ClientOnly>
-      <!-- Мобильные фильтры (Sheet) -->
-      <DynamicFiltersMobile
+      <!-- Мобильные фильтры (bottom sheet) -->
+      <MobileCatalogDrawer
         v-model="activeFilters"
         :open="isMobileFiltersOpen"
         :available-filters="availableFilters as unknown as AttributeWithValue[]"
@@ -2133,79 +2196,20 @@ else {
         :is-loading="isLoadingFilters"
         @update:open="isMobileFiltersOpen = $event"
       />
-
-      <!-- Drawer с подкатегориями -->
-      <Drawer v-model:open="isSubcategoriesDrawerOpen">
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle class="flex items-center gap-2">
-              <Icon name="lucide:layers" class="w-5 h-5 text-primary" />
-              Выберите подкатегории
-            </DrawerTitle>
-            <DrawerDescription>
-              Фильтрация применяется автоматически
-            </DrawerDescription>
-          </DrawerHeader>
-
-          <div class="px-4 pb-6 space-y-2 max-h-[60vh] overflow-y-auto">
-            <button
-              v-for="cat in subcategories"
-              :key="cat.id"
-              type="button"
-              class="w-full flex items-center gap-4 p-4 rounded-xl transition-all duration-200"
-              :class="[
-                activeFilters.subCategoryIds.includes(cat.id)
-                  ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-lg shadow-blue-500/25'
-                  : 'bg-secondary/60 hover:bg-secondary hover:shadow-md active:scale-[0.98]',
-              ]"
-              @click="toggleSubCategory(cat.id)"
-            >
-              <div
-                class="flex items-center justify-center w-10 h-10 rounded-xl shrink-0"
-                :class="
-                  activeFilters.subCategoryIds.includes(cat.id)
-                    ? 'bg-white/20'
-                    : 'bg-background/50'
-                "
-              >
-                <Icon
-                  :name="
-                    activeFilters.subCategoryIds.includes(cat.id)
-                      ? 'lucide:check'
-                      : 'lucide:folder'
-                  "
-                  class="w-5 h-5"
-                />
-              </div>
-              <div class="flex-1 text-left">
-                <div class="font-semibold text-base">
-                  {{ cat.name }}
-                </div>
-              </div>
-            </button>
-          </div>
-
-          <DrawerFooter class="gap-2">
-            <Button
-              v-if="activeFilters.subCategoryIds.length > 0"
-              variant="outline"
-              class="w-full"
-              @click="activeFilters.subCategoryIds = []"
-            >
-              <Icon name="lucide:x" class="w-4 h-4 mr-2" />
-              Сбросить все ({{ activeFilters.subCategoryIds.length }})
-            </Button>
-            <DrawerClose as-child>
-              <Button class="w-full">
-                <Icon name="lucide:check" class="w-4 h-4 mr-2" />
-                Применить
-              </Button>
-            </DrawerClose>
-          </DrawerFooter>
-        </DrawerContent>
-      </Drawer>
     </ClientOnly>
   </div>
+
+  <!-- Плавающая кнопка «Наверх» — только десктоп, из Категория.dc.html -->
+  <button
+    v-if="showScrollTop"
+    type="button"
+    class="hidden lg:flex cf-scrolltop"
+    aria-label="Наверх"
+    @click="scrollToTop"
+  >
+    <Icon name="lucide:arrow-up" class="w-4 h-4 text-primary" />
+    Наверх
+  </button>
 </template>
 
 <style scoped>
@@ -2216,5 +2220,136 @@ else {
   100% {
     background-position: 200% center;
   }
+}
+
+/* ─── Стеклянные пилюли из Категория.dc.html (панель управления, чипсы, "Наверх") ─── */
+.cf-glass-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 42px;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.9), rgba(224, 233, 247, 0.55));
+  backdrop-filter: blur(14px) saturate(1.7);
+  -webkit-backdrop-filter: blur(14px) saturate(1.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    inset 0 -1px 2px rgba(15, 23, 42, 0.06),
+    0 6px 18px rgba(15, 23, 42, 0.1);
+  color: var(--foreground);
+  font: 600 14px var(--font-sans);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.cf-glass-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.cf-glass-btn--active {
+  border-color: var(--primary);
+  background: linear-gradient(150deg, rgba(219, 234, 254, 0.95), rgba(191, 219, 254, 0.6));
+  color: var(--blue-700);
+}
+
+.cf-glass-btn--lg {
+  height: 50px;
+  padding: 0 26px;
+  font-size: 15px;
+}
+
+.cf-glass-btn--primary {
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: linear-gradient(150deg, rgba(77, 148, 255, 0.95), rgba(23, 101, 235, 0.85));
+  color: #fff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    inset 0 -2px 8px rgba(6, 53, 138, 0.28),
+    0 8px 20px rgba(43, 127, 255, 0.35);
+}
+
+.cf-glass-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font: 700 11px var(--font-sans);
+}
+
+.cf-chip-scroller {
+  /* display is driven by the Tailwind flex/hidden/lg:* utilities on each
+     usage site — a scoped display here would out-specificity them (see
+     mobilenav-dc-port memory) and the element would never actually hide. */
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.cf-chip-scroller::-webkit-scrollbar {
+  display: none;
+}
+
+.cf-chip {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: none;
+  background: var(--muted);
+  color: var(--foreground);
+  font: 600 13.5px var(--font-sans);
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.cf-chip--active {
+  background: rgba(43, 127, 255, 0.12);
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.cf-scrolltop {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 70;
+  align-items: center;
+  gap: 7px;
+  height: 44px;
+  padding: 0 18px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.18));
+  backdrop-filter: blur(24px) saturate(1.9);
+  -webkit-backdrop-filter: blur(24px) saturate(1.9);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -1px 1px rgba(15, 23, 42, 0.05),
+    0 12px 32px rgba(15, 23, 42, 0.18);
+  color: var(--foreground);
+  font: 700 13px var(--font-sans);
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.cf-scrolltop:active {
+  transform: translateX(-50%) scale(0.96);
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,25 +4,22 @@ import type {
   RecommendedProduct,
 } from '@/types'
 import { useQuery } from '@tanstack/vue-query'
-import { useMediaQuery } from '@vueuse/core'
 import { useSlides } from '@/composables/slides/useSlides'
-import { carouselContainerVariants } from '@/lib/variants'
+import {
+  HOME_CHIPS_CATEGORY_LIMIT,
+  HOME_STATIC_CHIPS,
+} from '@/constants/homePlaceholders'
+import { carouselContainerVariants, sectionSpacingVariants } from '@/lib/variants'
 import { useAuthStore } from '@/stores/auth'
 import { usePersonalizationStore } from '@/stores/core/personalizationStore'
 import { useProfileStore } from '@/stores/core/profileStore'
-import { usePopularCategoriesStore } from '@/stores/publicStore/popularCategoriesStore'
+import { useCategoriesStore } from '@/stores/publicStore/categoriesStore'
 import { useProductsStore } from '@/stores/publicStore/productsStore'
 import { useRecommendationsStore } from '@/stores/publicStore/recommendationsStore'
 import { useWishlistStore } from '@/stores/publicStore/wishlistStore'
 
-// Lazy load non-critical components
-const LazyBanners = defineAsyncComponent(() => import('@/components/home/Banners.vue'))
-const LazyBonusCard = defineAsyncComponent(() => import('@/components/home/BonusProgramCard.vue'))
-const LazyFeaturedProduct = defineAsyncComponent(() => import('@/components/home/FeaturedProduct.vue'))
+// Ленивая загрузка некритичных блоков
 const LazyProductsCarousel = defineAsyncComponent(() => import('@/components/home/ProductsCarousel.vue'))
-
-// Detect mobile for conditional loading — useMediaQuery кешируется, не дёргает DOM при рендере
-const isMobile = useMediaQuery('(max-width: 767px)')
 
 const authStore = useAuthStore()
 const profileStore = useProfileStore()
@@ -30,7 +27,7 @@ const recommendationsStore = useRecommendationsStore()
 const personalizationStore = usePersonalizationStore()
 const productsStore = useProductsStore()
 const wishlistStore = useWishlistStore()
-const popularCategoriesStore = usePopularCategoriesStore()
+const categoriesStore = useCategoriesStore()
 const { slides, isLoading: isLoadingSlides, error: slidesError } = useSlides()
 
 const { isLoggedIn, user } = storeToRefs(authStore)
@@ -47,35 +44,30 @@ function getCachedData(key: string) {
 }
 
 const alwaysContainedClass = carouselContainerVariants({ contained: 'always' })
-const desktopContainedClass = carouselContainerVariants({
-  contained: 'desktop',
-})
 
 interface HomePersonalData {
   recommended: RecommendedProduct[]
   wishlist: ProductWithGallery[]
 }
 
-// ✅ SSR prefetch — LAZY для небл окирующего рендера
+// ✅ SSR prefetch — прогреваем дерево категорий для секции «Популярные категории»
 useAsyncData(
   'home-ssr-critical',
   async () => {
-    await popularCategoriesStore.fetchPopularCategories()
-    return {
-      categories: popularCategoriesStore.popularCategories || [],
-    }
+    await categoriesStore.fetchCategoryData()
+    return { ok: true }
   },
   { server: true, lazy: true, getCachedData },
 )
 
-// TanStack Query — рекомендации
+// TanStack Query — рекомендации (лента «Подобрали для вас»)
 const recommendationsQueryKey = computed(() => [
   'home-recommendations',
   user.value?.id,
   personalizationTrigger.value,
   isLoggedIn.value,
 ])
- 
+
 // @ts-expect-error - Type instantiation depth issue with TanStack Query + Supabase complex types.
 const {
   data: mainPersonalData,
@@ -117,7 +109,7 @@ const showRecommendationsSkeleton = computed(
         && mainPersonalData.value.wishlist.length === 0)),
 )
 
-// TanStack Query — популярные товары
+// TanStack Query — популярные товары (fallback ленты для гостей)
 const popularQuery = useQuery<ProductWithGallery[]>({
   queryKey: ['home-popular'],
   queryFn: () => productsStore.fetchPopularProducts(10),
@@ -128,69 +120,22 @@ const popularQuery = useQuery<ProductWithGallery[]>({
 })
 
 const popularProductsData = popularQuery.data
-const isLoadingPopular = popularQuery.isLoading
 const isFetchingPopular = popularQuery.isFetching
 
 const popularProducts = computed<ProductWithGallery[]>(
   () => popularProductsData.value || [],
 )
 
-// TanStack Query — новинки
-const {
-  data: newestProductsData,
-  isLoading: isLoadingNewest,
-  isFetching: isFetchingNewest,
-} = useQuery<ProductWithGallery[]>({
-  queryKey: ['home-newest'],
-  queryFn: () => productsStore.fetchNewestProducts(10),
-  staleTime: 5 * 60 * 1000,
-  gcTime: 15 * 60 * 1000,
-  refetchOnMount: false,
-  refetchOnWindowFocus: false,
-})
-
-const newestProducts = computed<ProductWithGallery[]>(
-  () => newestProductsData.value || [],
-)
-
 const showPopularSkeleton = computed(
   () =>
-    (isLoadingPopular.value || isFetchingPopular.value)
+    (popularQuery.isLoading.value || popularQuery.isFetching.value)
     && !popularProductsData.value,
 )
 
-const showNewestSkeleton = computed(
-  () =>
-    (isLoadingNewest.value || isFetchingNewest.value)
-    && !newestProductsData.value,
-)
 const isLoadingMainBlock = computed(
   () => showRecommendationsSkeleton.value || showPopularSkeleton.value,
 )
 
-// --- Progressive Loading ---
-const shouldRenderSecondaryBlocks = ref(false)
-const shouldRenderLowerBlocks = ref(false)
-
-onMounted(() => {
-  // Загружаем основные блоки чуть позже
-  requestIdleCallback(() => {
-    shouldRenderSecondaryBlocks.value = true
-  })
-
-  // Загружаем нижние блоки ещё позже
-  setTimeout(() => {
-    shouldRenderLowerBlocks.value = true
-  }, 1000)
-})
-
-// ---------------------------------------------------------------------------
-// Вычисляемые флаги для условного рендера карусельных блоков.
-// ...
-
-// ВАЖНО: v-if снаружи LazyHydration — компонент либо есть в DOM (и будет
-// гидрирован по стратегии), либо его нет вовсе. Это корректно.
-// ---------------------------------------------------------------------------
 const showWishlistCarousel = computed(
   () => isLoggedIn.value && wishlistProducts.value.length > 0,
 )
@@ -203,18 +148,49 @@ const showPopularFallbackCarousel = computed(
     && popularProducts.value
     && popularProducts.value.length > 0,
 )
-const showNewestCarousel = computed(
-  () => newestProducts.value && newestProducts.value.length > 0,
-)
 
-// ---------------------------------------------------------------------------
-// Скелетоны для карусельных блоков.
-// ИСПРАВЛЕНО: вместо ClientOnly + template#fallback используем серверный рендер
-// скелетона через v-if/v-else прямо в шаблоне. Скелетон виден на SSR и во
-// время загрузки данных, LazyHydration-карусель появляется когда данные готовы.
-// ---------------------------------------------------------------------------
+// --- Быстрые чипы: статические ссылки + корневые категории из menuTree ---
+const chipItems = computed(() => {
+  const roots = (categoriesStore.menuTree ?? [])
+    .slice(0, HOME_CHIPS_CATEGORY_LIMIT)
+    .map(r => ({
+      id: r.slug,
+      label: r.name,
+      to: r.href || `/catalog/${r.slug}`,
+      icon: r.icon_name || null,
+    }))
+  return [
+    ...HOME_STATIC_CHIPS.map(c => ({ ...c, icon: null as string | null })),
+    ...roots,
+  ]
+})
 
-// SEO
+// --- Progressive Loading ---
+const shouldRenderSecondaryBlocks = ref(false)
+const shouldRenderLowerBlocks = ref(false)
+
+onMounted(() => {
+  requestIdleCallback(() => {
+    shouldRenderSecondaryBlocks.value = true
+  })
+  setTimeout(() => {
+    shouldRenderLowerBlocks.value = true
+  }, 1000)
+})
+
+// --- «Перейти к покупкам» → скролл к ленте товаров ---
+const shopSectionRef = ref<HTMLElement | null>(null)
+function scrollToShop() {
+  const el = shopSectionRef.value
+  if (!el)
+    return
+  const top = el.getBoundingClientRect().top + window.scrollY - 80
+  window.scrollTo({ top, behavior: 'smooth' })
+}
+
+// ==========================================================================
+// SEO — сохранено без изменений при редизайне
+// ==========================================================================
 const siteUrl = 'https://uhti.kz'
 const siteName = 'Ухтышка'
 const metaTitle = `Купить детские игрушки в Алматы | ${siteName}`
@@ -263,7 +239,6 @@ useSeoMeta({
     'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1',
 })
 
-// Simplified static schemas (no reactive dependencies)
 const storeSchema = {
   '@context': 'https://schema.org',
   '@type': 'Store',
@@ -372,7 +347,7 @@ useRobotsRule({ index: true, follow: true })
 
 <template>
   <div>
-    <!-- ✅ Скрытый SEO-текст -->
+    <!-- ✅ Скрытый SEO-текст: единственный h1 страницы -->
     <div class="sr-only">
       <h1>{{ siteName }} - Интернет-магазин детских игрушек в Казахстане</h1>
       <p>
@@ -382,248 +357,321 @@ useRobotsRule({ index: true, follow: true })
       </p>
     </div>
 
-    <!-- Статус активного заказа -->
-    <div :class="alwaysContainedClass" class="py-4">
-      <ClientOnly>
-        <!--
-          ClientOnly здесь оправдан: блок зависит от auth-стора,
-          который не доступен на SSR, и не является LazyHydration-компонентом.
-        -->
-        <div v-if="isLoggedIn">
-          <div
-            v-if="isAdmin"
-            class="p-4 bg-blue-50 border border-blue-200 rounded-md"
-          >
-            <NuxtLink
-              to="/admin"
-              class="font-semibold text-primary hover:underline"
-            >
-              Перейти в панель администратора
-            </NuxtLink>
-          </div>
-          <HomeActiveOrderStatus v-else />
-        </div>
-        <template #fallback>
-          <div class="h-0" />
-        </template>
-      </ClientOnly>
-    </div>
+    <!-- ============ HERO (full-bleed) ============ -->
+    <HomeHero
+      :slides="slides || []"
+      :is-loading="isLoadingSlides"
+      :error="slidesError"
+    />
 
-    <!-- ✅ Слайдер в ClientOnly (нет SSR-данных, нужна клиентская логика) -->
-    <ClientOnly>
-      <template v-if="!isMobile || slides?.length">
-        <CommonAppCarousel
-          :is-loading="isLoadingSlides"
-          :error="slidesError"
-          :slides="slides || []"
-        />
-      </template>
-      <template #fallback>
-        <div :class="carouselContainerVariants({ contained: 'desktop' })">
-          <div class="py-4">
-            <div class="p-1">
-              <div
-                class="w-full h-auto rounded-2xl aspect-3/2 md:aspect-19/6 lg:aspect-21/9 bg-muted animate-pulse"
-              />
-            </div>
-          </div>
-        </div>
-      </template>
-    </ClientOnly>
+    <!-- Мобильная распорка под фиксированным героем -->
+    <div class="home-hero-spacer" />
 
-    <!-- ✅ Баннеры (без изменений — уже было корректно) -->
-    <div :class="alwaysContainedClass">
-      <LazyBanners />
-    </div>
-
-    <!-- Бренды в коллапсе -->
-    <div :class="alwaysContainedClass" class="py-6">
-      <ClientOnly>
-        <HomeBrandsCollapsible v-if="shouldRenderSecondaryBlocks" />
-      </ClientOnly>
-    </div>
-
-    <!-- Популярные категории -->
-    <div :class="desktopContainedClass">
-      <HomePopularCategories v-if="shouldRenderSecondaryBlocks" />
-    </div>
-
-    <!-- Карточки бонусов (без изменений — уже было корректно) -->
-    <div :class="alwaysContainedClass" class="py-8 md:py-12">
-      <h2 class="text-2xl md:text-3xl font-bold tracking-tight text-start mb-8">
-        Акции и бонусы
-      </h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
-        <LazyBonusCard />
-        <LazyFeaturedProduct />
+    <!-- ============ БЕЛЫЙ ЛИСТ КОНТЕНТА ============ -->
+    <div class="home-content">
+      <!-- Десктопная «таблетка» перехода к покупкам -->
+      <div class="hidden lg:block home-shop-tab-wrap">
+        <button type="button" class="home-shop-tab" @click="scrollToShop">
+          Перейти к покупкам
+          <Icon name="lucide:chevron-down" class="size-4" />
+        </button>
       </div>
-    </div>
 
-    <!--
-      ✅ Карусели товаров — ClientOnly + обычные (не LazyHydration) компоненты.
-    -->
-    <div :class="alwaysContainedClass" class="py-8 md:py-12">
+      <!-- Мобильная липкая строка поиска -->
+      <div class="lg:hidden">
+        <HomeStickySearchRow />
+      </div>
+
+      <!-- Статус активного заказа -->
+      <div :class="[alwaysContainedClass, sectionSpacingVariants({ size: 'xs' })]">
+        <ClientOnly>
+          <div v-if="isLoggedIn">
+            <div
+              v-if="isAdmin"
+              class="p-4 bg-blue-50 border border-blue-200 rounded-md"
+            >
+              <NuxtLink
+                to="/admin"
+                class="font-semibold text-primary hover:underline"
+              >
+                Перейти в панель администратора
+              </NuxtLink>
+            </div>
+            <HomeActiveOrderStatus v-else />
+          </div>
+          <template #fallback>
+            <div class="h-0" />
+          </template>
+        </ClientOnly>
+      </div>
+
+      <!-- Быстрые чипы -->
+      <section ref="shopSectionRef" :class="alwaysContainedClass" class="pt-2 pb-1 scroll-mt-20">
+        <div class="rail-bleed">
+          <HomeCategoryChips :items="chipItems" />
+        </div>
+      </section>
+
+      <!-- Подобрали для вас.
+           Карусели сами задают себе ширину (заголовок — контейнер 'always',
+           лента — контейнер 'desktop' + отступ внутри ленты), поэтому внешнего
+           контейнера здесь быть НЕ должно: он давал двойной padding.
+           ProductCarouselSectionSkeleton повторяет их отступы 1-в-1. -->
       <ClientOnly>
         <template v-if="isLoadingMainBlock || !shouldRenderLowerBlocks">
-          <Skeleton class="h-8 w-1/3 mb-8 rounded-lg" />
-          <ProductCarouselSkeleton />
+          <ProductCarouselSectionSkeleton />
         </template>
         <template v-else>
-          <!-- Избранное (только для залогиненных) -->
           <LazyProductsCarousel
             v-if="showWishlistCarousel"
             :is-loading="isFetchingRecommendations"
             :products="wishlistProducts"
             title="Ваше избранное"
             see-all-link="/profile/wishlist"
-            class="mt-16 pt-8 border-t"
           />
-
-          <!-- Рекомендации ИЛИ Популярные товары -->
           <LazyProductsCarousel
             v-if="showRecommendedCarousel"
             :is-loading="isFetchingRecommendations"
             :products="recommendedProducts"
-            title="Вам может понравиться"
+            title="Подобрали для вас"
             see-all-link="/catalog/all?recommended=true"
-            :class="{
-              'mt-16 pt-8 border-t': !isLoggedIn || wishlistProducts.length === 0,
-            }"
           />
           <LazyProductsCarousel
             v-else-if="showPopularFallbackCarousel"
             :is-loading="isFetchingPopular"
             :products="popularProducts"
-            title="Популярные товары"
+            title="Подобрали для вас"
             see-all-link="/catalog/all?sort_by=popularity"
-            :class="{
-              'mt-16 pt-8 border-t': !isLoggedIn || wishlistProducts.length === 0,
-            }"
           />
         </template>
-        <!-- SSR fallback: статичный скелетон, не участвует в гидрации -->
         <template #fallback>
-          <Skeleton class="h-8 w-1/3 mb-8 rounded-lg" />
-          <ProductCarouselSkeleton />
+          <ProductCarouselSectionSkeleton />
         </template>
       </ClientOnly>
-    </div>
 
-    <!--
-      ✅ Новые поступления — та же логика: данные client-only → ClientOnly-обёртка.
-    -->
-    <div :class="alwaysContainedClass" class="py-8 md:py-12">
-      <ClientOnly>
-        <template v-if="showNewestSkeleton || !shouldRenderLowerBlocks">
-          <Skeleton class="h-8 w-1/3 mb-8 rounded-lg" />
-          <ProductCarouselSkeleton />
-        </template>
-        <LazyProductsCarousel
-          v-else-if="showNewestCarousel"
-          :is-loading="isFetchingNewest"
-          :products="newestProducts"
-          title="Новые поступления"
-          see-all-link="/catalog/all?sort_by=newest"
-          class="pt-4 border-t"
-        />
-        <template #fallback>
-          <Skeleton class="h-8 w-1/3 mb-8 rounded-lg" />
-          <ProductCarouselSkeleton />
-        </template>
-      </ClientOnly>
-    </div>
+      <!-- Популярные категории -->
+      <div :class="[alwaysContainedClass, sectionSpacingVariants({ size: 'xs' })]">
+        <HomePopularCategories v-if="shouldRenderSecondaryBlocks" />
+      </div>
 
-    <!-- SEO-блок -->
-    <div :class="alwaysContainedClass" class="py-12 md:py-16 border-t">
-      <div class="prose prose-lg max-w-none">
-        <h2 class="text-2xl md:text-3xl font-bold mb-6">
-          Интернет-магазин детских игрушек {{ siteName }} в Алматы
-        </h2>
-        <div class="grid md:grid-cols-2 gap-8 text-muted-foreground">
-          <div>
-            <h3 class="text-xl font-semibold text-foreground mb-3">
-              Широкий ассортимент игрушек
-            </h3>
-            <p class="mb-4">
-              В нашем интернет-магазине в Алматы вы найдете огромный выбор
-              детских игрушек для детей всех возрастов: от развивающих игрушек
-              для малышей до конструкторов и настольных игр для школьников.
-            </p>
-            <ul class="space-y-2 list-disc list-inside">
-              <li>Развивающие игрушки и игры</li>
-              <li>Конструкторы и пазлы</li>
-              <li>Куклы и машинки</li>
-              <li>Мягкие игрушки</li>
-              <li>Настольные игры</li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="text-xl font-semibold text-foreground mb-3">
-              Официальные бренды
-            </h3>
-            <p class="mb-4">
-              Мы работаем с ведущими производителями детских игрушек. В нашем
-              каталоге представлены только оригинальные товары от проверенных
-              брендов с гарантией качества.
-            </p>
-          </div>
+      <!-- Популярные бренды -->
+      <div :class="[alwaysContainedClass, sectionSpacingVariants({ size: 'xs' })]">
+        <ClientOnly>
+          <HomeBrandsRail v-if="shouldRenderSecondaryBlocks" />
+        </ClientOnly>
+      </div>
+
+      <!-- Акции и бонусы -->
+      <div :class="[alwaysContainedClass, sectionSpacingVariants({ size: 'md' })]">
+        <div class="flex items-baseline justify-between gap-3 mb-5">
+          <h2 class="m-0 font-bold tracking-tight text-[clamp(22px,3vw,32px)]">
+            Акции и бонусы
+          </h2>
+          <span class="hidden sm:inline-flex items-center gap-1.5 text-sm font-semibold text-muted-foreground">
+            <Icon name="lucide:sparkles" class="size-4 text-[color:var(--color-orange-600)]" />
+            Выгода каждый день
+          </span>
         </div>
-        <div class="mt-8 pt-8 border-t">
-          <h3 class="text-xl font-semibold text-foreground mb-3">
-            Преимущества покупки в {{ siteName }}
-          </h3>
-          <ul class="grid md:grid-cols-2 gap-3">
-            <li class="flex items-start gap-2">
-              <Icon
-                name="lucide:map-pin"
-                class="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5"
-              />
-              <span><strong>Доставка по Алматы</strong> - быстрая и удобная</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <Icon
-                name="lucide:gift"
-                class="w-5 h-5 text-orange-600 flex-shrink-0 mt-0.5"
-              />
-              <span><strong>Бонусная программа</strong> - накапливайте баллы за покупки</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <Icon
-                name="lucide:shield-check"
-                class="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5"
-              />
-              <span><strong>Гарантия качества</strong> - только сертифицированные товары</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <Icon
-                name="lucide:headphones"
-                class="w-5 h-5 text-purple-600 flex-shrink-0 mt-0.5"
-              />
-              <span><strong>Поддержка 24/7</strong> - всегда рады помочь</span>
-            </li>
-          </ul>
-          <div class="mt-6 pt-6 border-t">
-            <div class="flex items-center gap-3">
-              <Icon
-                name="lucide:phone"
-                class="w-6 h-6 text-primary flex-shrink-0"
-              />
-              <div>
-                <p class="text-sm text-muted-foreground">
-                  Свяжитесь с нами:
-                </p>
-                <a
-                  href="tel:+77771243843"
-                  class="text-lg font-semibold text-foreground hover:text-primary transition-colors"
-                >
-                  +7 (777) 124-38-43
-                </a>
+        <ClientOnly>
+          <template v-if="shouldRenderLowerBlocks">
+            <HomeLoyaltyBanner class="mb-4" />
+            <div class="home-promo-grid">
+              <HomeDealOfTheDayCard />
+              <HomePromoBenefitTiles />
+            </div>
+          </template>
+          <template #fallback>
+            <Skeleton class="h-64 w-full rounded-3xl" />
+          </template>
+        </ClientOnly>
+      </div>
+
+      <!-- Хиты продаж -->
+      <div :class="[alwaysContainedClass, sectionSpacingVariants({ size: 'xs' })]">
+        <ClientOnly>
+          <HomeBestsellersGrid v-if="shouldRenderLowerBlocks" />
+        </ClientOnly>
+      </div>
+
+      <!-- SEO-блок (сохранён).
+           Нижнего отступа здесь быть НЕ должно: блок последний в `.home-content`,
+           и его padding-bottom давал белую полосу между листом и футером.
+           Поэтому вместо sectionSpacingVariants({ size: 'lg' }) — только верхний
+           отступ, теми же значениями (py-12 md:py-16 → pt-12 md:pt-16). -->
+      <div :class="alwaysContainedClass" class="border-t pt-12 md:pt-16">
+        <div class="prose prose-lg max-w-none">
+          <h2 class="text-2xl md:text-3xl font-bold mb-6">
+            Интернет-магазин детских игрушек {{ siteName }} в Алматы
+          </h2>
+          <div class="grid md:grid-cols-2 gap-8 text-muted-foreground">
+            <div>
+              <h3 class="text-xl font-semibold text-foreground mb-3">
+                Широкий ассортимент игрушек
+              </h3>
+              <p class="mb-4">
+                В нашем интернет-магазине в Алматы вы найдете огромный выбор
+                детских игрушек для детей всех возрастов: от развивающих игрушек
+                для малышей до конструкторов и настольных игр для школьников.
+              </p>
+              <ul class="space-y-2 list-disc list-inside">
+                <li>Развивающие игрушки и игры</li>
+                <li>Конструкторы и пазлы</li>
+                <li>Куклы и машинки</li>
+                <li>Мягкие игрушки</li>
+                <li>Настольные игры</li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-foreground mb-3">
+                Официальные бренды
+              </h3>
+              <p class="mb-4">
+                Мы работаем с ведущими производителями детских игрушек. В нашем
+                каталоге представлены только оригинальные товары от проверенных
+                брендов с гарантией качества.
+              </p>
+            </div>
+          </div>
+          <div class="mt-8 pt-8 border-t">
+            <h3 class="text-xl font-semibold text-foreground mb-3">
+              Преимущества покупки в {{ siteName }}
+            </h3>
+            <ul class="grid md:grid-cols-2 gap-3">
+              <li class="flex items-start gap-2">
+                <Icon
+                  name="lucide:map-pin"
+                  class="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5"
+                />
+                <span><strong>Доставка по Алматы</strong> - быстрая и удобная</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <Icon
+                  name="lucide:gift"
+                  class="w-5 h-5 text-orange-600 flex-shrink-0 mt-0.5"
+                />
+                <span><strong>Бонусная программа</strong> - накапливайте баллы за покупки</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <Icon
+                  name="lucide:shield-check"
+                  class="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5"
+                />
+                <span><strong>Гарантия качества</strong> - только сертифицированные товары</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <Icon
+                  name="lucide:headphones"
+                  class="w-5 h-5 text-purple-600 flex-shrink-0 mt-0.5"
+                />
+                <span><strong>Поддержка 24/7</strong> - всегда рады помочь</span>
+              </li>
+            </ul>
+            <div class="mt-6 pt-6 border-t">
+              <div class="flex items-center gap-3">
+                <Icon
+                  name="lucide:phone"
+                  class="w-6 h-6 text-primary flex-shrink-0"
+                />
+                <div>
+                  <p class="text-sm text-muted-foreground">
+                    Свяжитесь с нами:
+                  </p>
+                  <a
+                    href="tel:+77771243843"
+                    class="text-lg font-semibold text-foreground hover:text-primary transition-colors"
+                  >
+                    +7 (777) 124-38-43
+                  </a>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-
   </div>
 </template>
+
+<style scoped>
+/* Мобильная распорка = высота фиксированного героя; на десктопе героя нет
+   поверх, лист наезжает отрицательным margin'ом (см. .home-content). */
+.home-hero-spacer {
+  height: min(62vh, 540px);
+  background: #dfe7ee;
+}
+
+.home-content {
+  position: relative;
+  z-index: 6;
+  margin-top: -18px;
+  background: #fff;
+  border-radius: 22px 22px 0 0;
+  box-shadow: 0 -12px 28px rgb(15 23 42 / 0.18);
+  min-height: 70vh;
+}
+
+.home-shop-tab-wrap {
+  position: relative;
+  height: 0;
+}
+
+.home-shop-tab {
+  position: absolute;
+  top: -19px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 7;
+  height: 38px;
+  padding: 0 22px;
+  border-radius: 999px;
+  background: #fff;
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 14px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.home-promo-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+/* Edge-bleed рельсов на мобильном (как .rail-bleed в прототипе).
+   Отступ обязан браться из --page-gutter — иначе рельс вылезает за контейнер
+   и даёт горизонтальный скролл всей страницы. */
+.rail-bleed {
+  margin-inline: 0;
+}
+
+@media (max-width: 767px) {
+  .rail-bleed {
+    margin-inline: calc(-1 * var(--page-gutter));
+    padding-inline: var(--page-gutter);
+  }
+}
+
+@media (min-width: 1024px) {
+  .home-hero-spacer {
+    display: none;
+  }
+
+  .home-content {
+    margin-top: clamp(-60px, -4vw, -36px);
+    border-radius: 28px 28px 0 0;
+    box-shadow: 0 -10px 30px rgb(0 0 0 / 0.07);
+    min-height: 0;
+  }
+
+  .home-promo-grid {
+    grid-template-columns: 1.5fr 1fr;
+    gap: 20px;
+    align-items: stretch;
+  }
+}
+</style>

--- a/types/app.ts
+++ b/types/app.ts
@@ -7,3 +7,20 @@ export interface HeaderOverlay {
 }
 
 export const HeaderOverlayKey: InjectionKey<HeaderOverlay> = Symbol('HeaderOverlay')
+
+/**
+ * Режим отрисовки шапки.
+ *
+ * `solid`   — обычная шапка в потоке документа (все layout'ы, кроме главной).
+ * `overlay` — прозрачная шапка поверх героя на главной; при скролле
+ *             «схлопывается» в стеклянную плашку с отступами.
+ *
+ * Потомки шапки (HeaderBottom, AppTabBar) инжектят ключ С ДЕФОЛТОМ,
+ * поэтому остальные шесть layout'ов не требуют никаких изменений.
+ */
+export interface HeaderVariant {
+  variant: Readonly<Ref<'solid' | 'overlay'>>
+  isScrolled: Readonly<Ref<boolean>>
+}
+
+export const HeaderVariantKey: InjectionKey<HeaderVariant> = Symbol('HeaderVariant')

--- a/types/type.ts
+++ b/types/type.ts
@@ -456,6 +456,8 @@ export interface BaseProduct {
   // ⭐ Рейтинги и отзывы для Social Proof
   avg_rating?: number | null
   review_count?: number | null
+  // 🆕 Бейдж «Новинка» — колонка products.is_new (ещё не выбирается во всех запросах каталога)
+  is_new?: boolean | null
 }
 
 export interface SimpleAttributeOption {


### PR DESCRIPTION
…равки скролла

Ширина:
- `--page-gutter` (16/24/32/48px) в tailwind.css — единственный источник правды по боковым отступам. На него переведены все три варианта `carouselContainerVariants`, `.app-container` и все edge-bleed рельсы. До этого было три конкурирующих определения, из-за чего на мобильном лента вылезала за экран и давала горизонтальный скролл всей страницы.
- Карусели сделаны самодостаточными по ширине: оборачивать их снаружи в контейнер нельзя. Убран двойной контейнер на главной.
- `ProductCarouselSectionSkeleton` — дедупликация трёх копий разметки.

Порт главной по макету Claude Design:
- Новые: Hero (фиксированный слайдер), StickySearchRow, CategoryChips, BestsellersGrid, BrandsRail, DealOfTheDayCard, LoyaltyBanner, PromoBenefitTiles, useHomeChrome, homePlaceholders.
- SiteHeader (+ MegaMenu, Search), CategoryMobileHeader, CategoryScrollBar, MobileCatalogDrawer, layouts/CatalogListing.

Производительность скролла:
- Убран `backdrop-filter` с `.pc-wish` и `.pc-add` в ProductCard: их было по 18 штук на экран, 36 слоёв из 45 на главной. Каждый заставлял браузер переснимать и блюрить подложку на каждом кадре, из-за чего при быстром скролле секции пропадали и появлялись заново. Замер 390x844, CPU x6, парный A/B по 780 кадров реального скролла: медиана 47.5 -> 38.5ms, p90 105.2 -> 56.2ms, кадров >50ms 43% -> 15%. Непрозрачность градиентов слегка поднята, чтобы без размытия сквозь кнопки не просвечивало фото товара.

Слои на главной:
- Футер обёрнут в `.home-footer-layer` с непрозрачным фоном и `z-index: 1`. Он рендерится вне <main>, лист `.home-content` его не накрывал, и внизу страницы сквозь полупрозрачный `bg-muted/30` просвечивал фиксированный герой. `z-index` строго между героем (0) и листом (6): при равном с листом значении футер перекрывал липкую строку поиска.
- Резерв под нижнюю навигацию переехал с <main> на футер. На <main> он давал 64px прозрачной полосы между листом и футером и не работал по назначению — футер идёт после <main>, навигация всё равно перекрывала его низ. Резерв должен стоять в конце документа.
- У последнего SEO-блока убран нижний отступ: лист контента упирается в футер вплотную.


Claude-Session: https://claude.ai/code/session_01YSpyiSEyxPb2jxPfUtNXrY